### PR TITLE
Throw ExceptionInInitializerError rather than just printing stacktrace

### DIFF
--- a/src/main/java/org/xerial/snappy/Snappy.java
+++ b/src/main/java/org/xerial/snappy/Snappy.java
@@ -26,6 +26,7 @@ package org.xerial.snappy;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.ExceptionInInitializerError;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -33,6 +34,9 @@ import java.util.Properties;
 
 /**
  * Snappy API for data compression/decompression
+ *
+ * Note: if the native libraries cannot be loaded, then an ExceptionInInitializerError
+ * will be thrown at first use of this class.
  * 
  * @author leo
  * 
@@ -44,7 +48,7 @@ public class Snappy
             impl = SnappyLoader.load();
         }
         catch (Exception e) {
-            e.printStackTrace();
+            throw new ExceptionInInitializerError(e);
         }
     }
 


### PR DESCRIPTION
This is one way to address issue #12. Rather then printing a stacktrace to stderr if the native libraries cannot be loaded, an ExceptionInInitializerError will be thrown. Because Errors are not checked exceptions, this also adds to the class javadoc to point out that static initialization of Snappy can throw this Error.
