### PR TITLE
The Snappy Java Jar is not compatible with Apache Felix 4.2.1 Framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,12 +182,12 @@
                         <Import-Package>org.osgi.framework;version="[1.5,2)"</Import-Package>
                         <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
                         <Bundle-NativeCode>
-                        	org/xerial/snappy/native/Windows/amd64/snappyjava.dll;selection-filter="(&amp;(osgi.arch=x86_64)(osgi.os=win32))",
-                        	org/xerial/snappy/native/Windows/x86/snappyjava.dll;selection-filter="(&amp;(osgi.arch=x86)(osgi.os=win32))",
-                        	org/xerial/snappy/native/Mac/x86_64/libsnappyjava.jnilib;selection-filter="(&amp;(osgi.arch=x86_64)(osgi.os=macosx))",
-                        	org/xerial/snappy/native/Linux/amd64/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=x86_64)(osgi.os=linux))",
-                        	org/xerial/snappy/native/Linux/i386/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=x86)(osgi.os=linux))",
-                        	org/xerial/snappy/native/Linux/arm/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=arm)(osgi.os=linux))"
+                        	org/xerial/snappy/native/Windows/amd64/snappyjava.dll;osname=win32;processor=x86-64,
+                        	org/xerial/snappy/native/Windows/x86/snappyjava.dll;osname=win32;processor=x86,
+                        	org/xerial/snappy/native/Mac/x86_64/libsnappyjava.jnilib;osname=macosx;processor=x86-64,
+                        	org/xerial/snappy/native/Linux/amd64/libsnappyjava.so;osname=linux;processor=x86-64,
+                        	org/xerial/snappy/native/Linux/i386/libsnappyjava.so;osname=linux;processor=x86,
+                        	org/xerial/snappy/native/Linux/arm/libsnappyjava.so;osname=linux;processor=arm
                         </Bundle-NativeCode>
                         <!-- TODO: unsure about ARMHF -->
                     </instructions>
@@ -214,7 +214,7 @@
 					</archive>
 				</configuration>
 			</plugin>
-			
+
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -231,7 +231,7 @@
                     </filesets>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.2.1</version>
@@ -252,7 +252,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
 
         <extensions>
@@ -332,7 +332,7 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
-    
+
 </project>


### PR DESCRIPTION
The Snappy Bundle contains the Bundle-NativeCode instruction in a way it's not compatible with the [R4LibraryClause](http://svn.apache.org/viewvc/felix/releases/org.apache.felix.framework-4.2.1/src/main/java/org/apache/felix/framework/util/manifestparser/R4LibraryClause.java?view=markup) because the osname and processor definition is mandatory. They can not be replaced with selection-filter.

Snappy 1.0.5 and the 1.1.0-SNAPSHOT throws the same org.osgi.framework.BundleException: Unresolved constraint in bundle org.xerial.snappy.snappy-java [n]: No matching native libraries found. exception.

I saw in the fixed issues the Snappy was tested on Eclipse 3.8.1 but I couldn't tested so it has to be verified. I also updated the x86-64 from x86_64 regarding the [Bundle-NativeCode: OS/Processor values](http://www.osgi.org/Specifications/Reference)
