### PR TITLE
Build changes for Solaris x86 & Sparc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,18 @@ SNAPPY_UNPACKED:=$(TARGET)/snappy-extracted.log
 
 CXXFLAGS:=$(CXXFLAGS) -I$(SNAPPY_SRC_DIR)
 
+ifeq ($(OS_NAME),SunOS)
+	TAR:= gtar
+else
+	TAR:= tar
+endif
+
 $(SNAPPY_ARCHIVE):
 	@mkdir -p $(@D)
 	curl -o$@ http://snappy.googlecode.com/files/snappy-$(VERSION).tar.gz
 
 $(SNAPPY_UNPACKED): $(SNAPPY_ARCHIVE)
-	tar xvfz $< -C $(TARGET)	
+	$(TAR) xvfz $< -C $(TARGET)	
 	touch $@
 
 jni-header: $(SRC)/org/xerial/snappy/SnappyNative.h

--- a/Makefile.common
+++ b/Makefile.common
@@ -41,7 +41,7 @@ endif
 
 # os=Default is meant to be generic unix/linux
 
-known_os_archs := Linux-x86 Linux-x86_64 Linux-arm Linux-armhf Mac-x86 Mac-x86_64 FreeBSD-x86_64 Windows-x86 Windows-x86_64
+known_os_archs := Linux-x86 Linux-x86_64 Linux-arm Linux-armhf Mac-x86 Mac-x86_64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc
 os_arch := $(OS_NAME)-$(OS_ARCH)
 
 ifeq (,$(findstring $(strip $(os_arch)),$(known_os_archs)))
@@ -71,6 +71,20 @@ Linux-x86_64_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include
 Linux-x86_64_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-x86_64_LIBNAME   := libsnappyjava.so
 Linux-x86_64_SNAPPY_FLAGS  := 
+
+SunOS-x86_CXX       := g++ 
+SunOS-x86_STRIP     := strip
+SunOS-x86_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden
+SunOS-x86_LINKFLAGS := -shared -static-libgcc -static-libstdc++
+SunOS-x86_LIBNAME   := libsnappyjava.so
+SunOS-x86_SNAPPY_FLAGS  := 
+
+SunOS-sparc_CXX       := g++ 
+SunOS-sparc_STRIP     := strip
+SunOS-sparc_CXXFLAGS  := -include lib/inc_linux/jni_md.h -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden
+SunOS-sparc_LINKFLAGS := -shared -static-libgcc -static-libstdc++
+SunOS-sparc_LIBNAME   := libsnappyjava.so
+SunOS-sparc_SNAPPY_FLAGS  := 
 
 # '-include lib/inc_linux/jni_md.h' is used to force the use of our version,
 # which defines JNIEXPORT differently; otherwise, since OpenJDK includes

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ See the [installation instruction](https://github.com/xerial/snappy-java/blob/de
     $ cd snappy-java
     $ make
     
+When building on Solaris use
+    
+    $ gmake
 
 A file `target/snappy-java-$(version).jar` is the product additionally containing the native library built for your platform.
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,8 @@
                         	org/xerial/snappy/native/Mac/x86_64/libsnappyjava.jnilib;selection-filter="(&amp;(osgi.arch=x86_64)(osgi.os=macosx))",
                         	org/xerial/snappy/native/Linux/x86_64/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=x86_64)(osgi.os=linux))",
                         	org/xerial/snappy/native/Linux/x86/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=x86)(osgi.os=linux))",
+                        	org/xerial/snappy/native/SunOS/x86/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=x86)(osgi.os=sunos))",
+                        	org/xerial/snappy/native/SunOS/sparc/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=sparc)(osgi.os=sunos))",
                         	org/xerial/snappy/native/Linux/arm/libsnappyjava.so;selection-filter="(&amp;(osgi.arch=arm)(osgi.os=linux))"
                         </Bundle-NativeCode>
                         <!-- TODO: unsure about ARMHF -->


### PR DESCRIPTION
I've added the GNU tar changes, put a note in the readme saying to use gmake on Solaris and added some extra names to Makefile.common. I've tested that the native library builds on Sparc, but I don't have access to a Sparc machine with Maven so I can't test the building of the Java library. It should build given Solaris x86 builds fine.
