### PR TITLE
Fix - Updated bundle activator to handle dynlib/jnilib issues on MacOS JDK7+

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyBundleActivator.java
+++ b/src/main/java/org/xerial/snappy/SnappyBundleActivator.java
@@ -49,7 +49,13 @@ public class SnappyBundleActivator implements BundleActivator
      */
     public void start(BundleContext context) throws Exception 
     {
-    	System.loadLibrary(System.mapLibraryName(LIBRARY_NAME));
+    	String library = System.mapLibraryName(LIBRARY_NAME);
+    	if (library.toLowerCase().endsWith(".dylib")) 
+    	{
+    		// some MacOS JDK7+ vendors map to dylib instead of jnilib
+    		library = library.replace(".dylib", ".jnilib");
+    	}
+    	System.loadLibrary(library);
     	SnappyLoader.setApi(new SnappyNative());
     }
 


### PR DESCRIPTION
Without this fix, snappy-java will not load native libraries on MacOS JDK7+.
