### PR TITLE
Add native library for ppc (32 bit)

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -42,7 +42,7 @@ endif
 
 # os=Default is meant to be generic unix/linux
 
-known_os_archs := Linux-x86 Linux-x86_64 Linux-arm Linux-armhf Linux-ppc64 Mac-x86 Mac-x86_64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc SunOS-x86_64 AIX-ppc64
+known_os_archs := Linux-x86 Linux-x86_64 Linux-arm Linux-armhf Linux-ppc Linux-ppc64 Mac-x86 Mac-x86_64 FreeBSD-x86_64 Windows-x86 Windows-x86_64 SunOS-x86 SunOS-sparc SunOS-x86_64 AIX-ppc64
 os_arch := $(OS_NAME)-$(OS_ARCH)
 IBM_JDK_7 := $(findstring IBM, $(shell $(JAVA) -version 2>&1 | grep IBM | grep "JRE 1.7"))
 
@@ -94,12 +94,23 @@ Linux-x86_64_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-x86_64_LIBNAME   := libsnappyjava.so
 Linux-x86_64_SNAPPY_FLAGS  := 
 
+Linux-ppc_CXX         := g++
+Linux-ppc_STRIP       := strip
+ifeq ($(IBM_JDK_7),)
+  Linux-ppc_CXXFLAGS    := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m32
+else
+  Linux-ppc_CXXFLAGS    := -DHAVE_CONFIG_H -include lib/inc_linux/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m32
+endif
+Linux-ppc_LINKFLAGS   := -shared -static-libgcc -static-libstdc++
+Linux-ppc_LIBNAME     := libsnappyjava.so
+Linux-ppc_SNAPPY_FLAGS  :=
+
 Linux-ppc64_CXX       := g++
 Linux-ppc64_STRIP     := strip
 ifeq ($(IBM_JDK_7),)
   Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 
 else
-  Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC
+  Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m64
 endif
 Linux-ppc64_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-ppc64_LIBNAME   := libsnappyjava.so


### PR DESCRIPTION
This is an identical copy of the Linux_ppc64 config, except that it has -m32 instead of -m64, and that it doesn't use `lib/inc_ibm/jni_md.h` which breaks 32-bit builds due to the removed definition of jlong for the 32-bit case.

Also, I added the missing -m64 to the second definition of `Linux-ppc64_CXXFLAGS`.