### PR TITLE
Fix FileNotFoundException while writing the library file

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyLoader.java
+++ b/src/main/java/org/xerial/snappy/SnappyLoader.java
@@ -300,11 +300,13 @@ public class SnappyLoader
         }
 
         // Temporary folder for the native lib. Use the value of org.xerial.snappy.tempdir or java.io.tmpdir
-        String tempFolder = new File(System.getProperty(KEY_SNAPPY_TEMPDIR,
-                System.getProperty("java.io.tmpdir"))).getAbsolutePath();
+        File tempFolder = new File(System.getProperty(KEY_SNAPPY_TEMPDIR, System.getProperty("java.io.tmpdir")));
+        if (!tempFolder.exists()) {
+            tempFolder.mkdir();
+        }
 
         // Extract and load a native library inside the jar file
-        return extractLibraryFile(snappyNativeLibraryPath, snappyNativeLibraryName, tempFolder);
+        return extractLibraryFile(snappyNativeLibraryPath, snappyNativeLibraryName, tempFolder.getAbsolutePath());
     }
 
 


### PR DESCRIPTION
Just faced with the problem when the temp directory doesn't exist at the beginning and FileOutputStream constructor throws an exception at line 212. I believe this should fix it, though I haven't tested it.