### PR TITLE
Make SnappyOutputStream.close() idempotent; guard against writing to closed stream

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -65,8 +65,9 @@ public class SnappyOutputStream extends OutputStream {
     private final BufferAllocator inputBufferAllocator;
     private final BufferAllocator outputBufferAllocator;
 
-    protected final byte[] inputBuffer;
-    protected final byte[] outputBuffer;
+    // The input and output buffer fields are set to null when closing this stream:
+    protected byte[] inputBuffer;
+    protected byte[] outputBuffer;
     private int inputCursor = 0;
     private int outputCursor = 0;
     private boolean closed;
@@ -340,6 +341,8 @@ public class SnappyOutputStream extends OutputStream {
             closed = true;
             inputBufferAllocator.release(inputBuffer);
             outputBufferAllocator.release(outputBuffer);
+            inputBuffer = null;
+            outputBuffer = null;
         }
     }
 

--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -69,6 +69,7 @@ public class SnappyOutputStream extends OutputStream {
     protected final byte[] outputBuffer;
     private int inputCursor = 0;
     private int outputCursor = 0;
+    private boolean closed;
 
     public SnappyOutputStream(OutputStream out) {
         this(out, DEFAULT_BLOCK_SIZE);
@@ -320,10 +321,14 @@ public class SnappyOutputStream extends OutputStream {
      */
     @Override
     public void close() throws IOException {
+        if (closed) {
+            return;
+        }
         try {
             flush();
             out.close();
         } finally {
+            closed = true;
             inputBufferAllocator.release(inputBuffer);
             outputBufferAllocator.release(outputBuffer);
         }

--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -232,6 +232,9 @@ public class SnappyOutputStream extends OutputStream {
      * @throws IOException
      */
     public void rawWrite(Object array, int byteOffset, int byteLength) throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
         int cursor = 0;
         while(cursor < byteLength) {
             int readLen = Math.min(byteLength - cursor, blockSize - inputCursor);
@@ -259,6 +262,9 @@ public class SnappyOutputStream extends OutputStream {
      */
     @Override
     public void write(int b) throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
         if(inputCursor >= inputBuffer.length) {
             compressInput();
         }
@@ -270,6 +276,9 @@ public class SnappyOutputStream extends OutputStream {
      */
     @Override
     public void flush() throws IOException {
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
         compressInput();
         dumpOutput();
         out.flush();

--- a/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.*;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import org.junit.Test;
 import org.xerial.snappy.buffer.BufferAllocatorFactory;
@@ -191,6 +192,37 @@ public class SnappyOutputStreamTest
         SnappyInputStream in3 = new SnappyInputStream(new ByteArrayInputStream(ba3.toByteArray()));
         assertEquals(3, in3.read());
         in3.close();
+    }
+
+    @Test
+    public void writingToClosedStreamShouldThrowIOException() throws IOException {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        SnappyOutputStream os = new SnappyOutputStream(b);
+        os.close();
+        try {
+            os.write(4);
+            fail("Expected write() to throw IOException");
+        } catch (IOException e) {
+            // Expected exception
+        }
+        try {
+            os.write(new int[] { 1, 2, 3, 4});
+            fail("Expected write() to throw IOException");
+        } catch (IOException e) {
+            // Expected exception
+        }
+    }
+
+    @Test
+    public void flushingClosedStreamShouldThrowIOException() throws IOException {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        SnappyOutputStream os = new SnappyOutputStream(b);
+        os.close();
+        try {
+            os.flush();
+        } catch (IOException e) {
+            // Expected exception
+        }
     }
 
     @Test

--- a/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
@@ -30,10 +30,12 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 import org.junit.Test;
 import org.xerial.snappy.buffer.BufferAllocatorFactory;
 import org.xerial.snappy.buffer.CachedBufferAllocator;
+import org.xerial.snappy.buffer.DefaultBufferAllocator;
 import org.xerial.util.FileResource;
 import org.xerial.util.log.Logger;
 
@@ -223,6 +225,18 @@ public class SnappyOutputStreamTest
         } catch (IOException e) {
             // Expected exception
         }
+    }
+
+    @Test
+    public void closingStreamShouldMakeBuffersEligibleForGarbageCollection() throws IOException {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        SnappyOutputStream os = new SnappyOutputStream(b, 4095, DefaultBufferAllocator.factory);
+        WeakReference<byte[]> inputBuffer = new WeakReference<byte[]>(os.inputBuffer);
+        WeakReference<byte[]> outputBuffer = new WeakReference<byte[]>(os.inputBuffer);
+        os.close();
+        System.gc();
+        assertNull(inputBuffer.get());
+        assertNull(outputBuffer.get());
     }
 
     @Test

--- a/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
@@ -187,8 +187,10 @@ public class SnappyOutputStreamTest
         os3.close();
         SnappyInputStream in2 = new SnappyInputStream(new ByteArrayInputStream(ba2.toByteArray()));
         assertEquals(2, in2.read());
+        in2.close();
         SnappyInputStream in3 = new SnappyInputStream(new ByteArrayInputStream(ba3.toByteArray()));
         assertEquals(3, in3.read());
+        in3.close();
     }
 
     @Test


### PR DESCRIPTION
This patch will fix #107, an issue where `SnappyOutputStream.close()` is not idempotent.

The first commit is a failing regression test which shows how a non-idempotent `close()` can lead to stream corruption issues.