### PR TITLE
Fix SnappyOutputStreamTest for big-endian platforms

### DIFF
--- a/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.ByteOrder;
 
 import org.junit.Test;
 import org.xerial.snappy.buffer.BufferAllocatorFactory;
@@ -163,10 +164,11 @@ public class SnappyOutputStreamTest
         // Compress the data once so that we know the expected size:
         byte[] expectedCompressedData = compressAsChunks(orig, Integer.MAX_VALUE);
         // Hardcoding an expected compressed size here will catch regressions that lower the
-        // compression quality. On little-endian platforms, the expected size is 91013; on
-        // big-endian platforms, the expected size is 90943.
-        assertTrue(String.format("unexpected compressed data size (%d)", expectedCompressedData.length),
-                   (expectedCompressedData.length == 91013 || expectedCompressedData.length == 90943));
+        // compression quality:
+        if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN)
+            assertEquals(90943, expectedCompressedData.length);
+        else
+            assertEquals(91013, expectedCompressedData.length);
         // The chunk size should not affect the size of the compressed output:
         int[] chunkSizes = new int[] {1, 100, 1023, 1024, 10000};
         for (int chunkSize : chunkSizes) {

--- a/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyOutputStreamTest.java
@@ -163,8 +163,10 @@ public class SnappyOutputStreamTest
         // Compress the data once so that we know the expected size:
         byte[] expectedCompressedData = compressAsChunks(orig, Integer.MAX_VALUE);
         // Hardcoding an expected compressed size here will catch regressions that lower the
-        // compression quality:
-        assertEquals(91013, expectedCompressedData.length);
+        // compression quality. On little-endian platforms, the expected size is 91013; on
+        // big-endian platforms, the expected size is 90943.
+        assertTrue(String.format("unexpected compressed data size (%d)", expectedCompressedData.length),
+                   (expectedCompressedData.length == 91013 || expectedCompressedData.length == 90943));
         // The chunk size should not affect the size of the compressed output:
         int[] chunkSizes = new int[] {1, 100, 1023, 1024, 10000};
         for (int chunkSize : chunkSizes) {


### PR DESCRIPTION
Fix issue #119.