### PR TITLE
Use non-JNI method for read(byte[])

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,5 @@ jdk:
   - openjdk7
   - oraclejdk7
 
-branches:
-  only:
-    - master
-    - develop
-
 script: ./sbt test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: scala
 scala:
-   - 2.11.1
+   - 2.11.7
+
+sudo: false
+
 jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
+  - oraclejdk8
 
 script: ./sbt test
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.8
+sbt.version=0.13.9
 

--- a/src/main/java/org/xerial/snappy/SnappyInputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyInputStream.java
@@ -157,10 +157,27 @@ public class SnappyInputStream
      * @see java.io.InputStream#read(byte[], int, int)
      */
     @Override
-    public int read(byte[] b, int off, int len)
+    public int read(byte[] b, int byteOffset, int byteLength)
             throws IOException
     {
-        return rawRead(b, off, len);
+        int writtenBytes = 0;
+        for (; writtenBytes < byteLength; ) {
+
+            if (uncompressedCursor >= uncompressedLimit) {
+                if (hasNextChunk()) {
+                    continue;
+                }
+                else {
+                    return writtenBytes == 0 ? -1 : writtenBytes;
+                }
+            }
+            int bytesToWrite = Math.min(uncompressedLimit - uncompressedCursor, byteLength - writtenBytes);
+            System.arraycopy(uncompressed, uncompressedCursor, b, byteOffset + writtenBytes, bytesToWrite);
+            writtenBytes += bytesToWrite;
+            uncompressedCursor += bytesToWrite;
+        }
+
+        return writtenBytes;
     }
 
     /**


### PR DESCRIPTION
For avoiding JNI overhead, reported in apache/spark#12074