### PR TITLE
Add a missing entry in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ $(TARGET)/jni-classes/org/xerial/snappy/BitShuffleNative.class: $(SRC)/org/xeria
 $(SRC)/org/xerial/snappy/BitShuffleNative.h: $(TARGET)/jni-classes/org/xerial/snappy/BitShuffleNative.class
 	$(JAVAH) -force -classpath $(TARGET)/jni-classes -o $@ org.xerial.snappy.BitShuffleNative
 
+$(SNAPPY_SRC): $(SNAPPY_GIT_UNPACKED)
 
 $(SNAPPY_OUT)/%.o: $(SNAPPY_SRC_DIR)/%.cc
 	@mkdir -p $(@D)


### PR DESCRIPTION
In the current master, `make` fails on max_x86-64 platforms because;
```
make: *** No rule to make target `target/snappy-1.1.3-Mac-x86_64/snappy-sinksource.o', needed by `target/snappy-1.1.3-Mac-x86_64/libsnappyjava.jnilib'.
```
This pr fixes this issue.