### PR TITLE
Use config.h and snappy-stubs-public.h generated by cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,6 @@ $(SRC)/org/xerial/snappy/BitShuffleNative.h: $(TARGET)/jni-classes/org/xerial/sn
 
 $(SNAPPY_SRC): $(SNAPPY_GIT_UNPACKED)
 
-# Need to use cmake generated header stub for Windows
-ifeq ($(OS_NAME),Windows)
-SNAPPY_CXX_OPTS:=-include$(SNAPPY_OUT)/snappy-stubs-public.h
-endif
-
 # aarch64 can use big-endian optimzied code
 ifeq ($(OS_ARCH),aarch64)
 SNAPPY_CXX_OPTS:=-DSNAPPY_IS_BIG_ENDIAN

--- a/Makefile.common
+++ b/Makefile.common
@@ -97,9 +97,9 @@ Linux-x86_64_SNAPPY_FLAGS  :=
 Linux-ppc_CXX         := g++
 Linux-ppc_STRIP       := strip
 ifeq ($(IBM_JDK_7),)
-  Linux-ppc_CXXFLAGS    := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m32
+  Linux-ppc_CXXFLAGS    := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m32
 else
-  Linux-ppc_CXXFLAGS    := -DHAVE_CONFIG_H -include lib/inc_linux/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m32
+  Linux-ppc_CXXFLAGS    := -include lib/inc_linux/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m32
 endif
 Linux-ppc_LINKFLAGS   := -shared -static-libgcc -static-libstdc++
 Linux-ppc_LIBNAME     := libsnappyjava.so
@@ -108,9 +108,9 @@ Linux-ppc_SNAPPY_FLAGS  :=
 Linux-ppc64le_CXX       := $(CROSS_PREFIX)g++
 Linux-ppc64le_STRIP     := $(CROSS_PREFIX)strip
 ifeq ($(IBM_JDK_7),)
-  Linux-ppc64le_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
+  Linux-ppc64le_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
 else
-  Linux-ppc64le_CXXFLAGS  := -DHAVE_CONFIG_H -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m64
+  Linux-ppc64le_CXXFLAGS  := -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m64
 endif
 Linux-ppc64le_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-ppc64le_LIBNAME   := libsnappyjava.so
@@ -119,9 +119,9 @@ Linux-ppc64le_SNAPPY_FLAGS  :=
 Linux-ppc64_CXX       := $(CROSS_PREFIX)g++
 Linux-ppc64_STRIP     := $(CROSS_PREFIX)strip
 ifeq ($(IBM_JDK_7),)
-  Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
+  Linux-ppc64_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
 else
-  Linux-ppc64_CXXFLAGS  := -DHAVE_CONFIG_H -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m64
+  Linux-ppc64_CXXFLAGS  := -include $(IBM_JDK_LIB)/jni_md.h -include $(IBM_JDK_LIB)/jniport.h -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -O2 -fPIC -m64
 endif
 Linux-ppc64_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-ppc64_LIBNAME   := libsnappyjava.so
@@ -131,9 +131,9 @@ AIX-ppc_CXX       := g++
 AIX-ppc_STRIP     := strip
 AIX-ppc_LIBNAME   := libsnappyjava.a
 ifeq ($(IBM_JDK_7),)
-  AIX-ppc_CXXFLAGS     := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -maix32
+  AIX-ppc_CXXFLAGS     := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -maix32
 else
-  AIX-ppc_CXXFLAGS     := -DHAVE_CONFIG_H -I$(JAVA_HOME)/include/aix -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -maix32
+  AIX-ppc_CXXFLAGS     := -I$(JAVA_HOME)/include/aix -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -maix32
 endif
 AIX-ppc_LINKFLAGS := -shared -static-libgcc -static-libstdc++ -lcrypt
 AIX-ppc_SNAPPY_FLAGS  :=
@@ -142,9 +142,9 @@ AIX-ppc64_CXX       := g++
 AIX-ppc64_STRIP     := strip -X64
 AIX-ppc64_LIBNAME   := libsnappyjava.a
 ifeq ($(IBM_JDK_7),)
-  AIX-ppc64_CXXFLAGS     := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -maix64
+  AIX-ppc64_CXXFLAGS     := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -maix64
 else
-  AIX-ppc64_CXXFLAGS     := -DHAVE_CONFIG_H -I$(JAVA_HOME)/include/aix -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -maix64
+  AIX-ppc64_CXXFLAGS     := -I$(JAVA_HOME)/include/aix -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -maix64
 endif
 AIX-ppc64_LINKFLAGS := -shared -static-libgcc -static-libstdc++ -lcrypt
 AIX-ppc64_SNAPPY_FLAGS  :=
@@ -152,9 +152,9 @@ AIX-ppc64_SNAPPY_FLAGS  :=
 Linux-s390_CXX       := g++
 Linux-s390_STRIP     := strip
 ifeq ($(IBM_JDK_7),)
-  Linux-s390_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m31
+  Linux-s390_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m31
 else
-  Linux-s390_CXXFLAGS  := -DHAVE_CONFIG_H -I$(JAVA_HOME)/include/linux -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -m31 
+  Linux-s390_CXXFLAGS  := -I$(JAVA_HOME)/include/linux -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -m31 
 endif
 Linux-s390_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-s390_LIBNAME   := libsnappyjava.so
@@ -163,9 +163,9 @@ Linux-s390_SNAPPY_FLAGS  :=
 Linux-s390x_CXX       := g++
 Linux-s390x_STRIP     := strip
 ifeq ($(IBM_JDK_7),)
-  Linux-s390x_CXXFLAGS  := -DHAVE_CONFIG_H -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
+  Linux-s390x_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64
 else
-  Linux-s390x_CXXFLAGS  := -DHAVE_CONFIG_H -I$(JAVA_HOME)/include/linux -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -m64 
+  Linux-s390x_CXXFLAGS  := -I$(JAVA_HOME)/include/linux -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -m64 
 endif
 Linux-s390x_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-s390x_LIBNAME   := libsnappyjava.so
@@ -277,7 +277,7 @@ SNAPPY_FLAGS := $($(os_arch)_SNAPPY_FLAGS)
 
 
 
-CXXFLAGS := $(CXXFLAGS) -Ilib/include
+CXXFLAGS := $(CXXFLAGS) -DHAVE_CONFIG_H
 ifneq ($(jni_include),)
 CXXFLAGS := $(CXXFLAGS) -I"$(jni_include)"
 endif

--- a/lib/include/config.h
+++ b/lib/include/config.h
@@ -1,5 +1,0 @@
-
-#ifndef __CONFIG_H
-#define __CONFIG_H
-
-#endif // __CONFIG_H


### PR DESCRIPTION
Now that the build process runs cmake on any platform, I think config.h and snappy-stub-public.h generated by cmake should be used throughout the platforms. This PR will allow s390x to use SNAPPY_IS_BIG_ENDIAN defined in config.h.

Please correct me if my understanding about the build process is wrong....
