### PR TITLE
[DOC] Optimize SnappyOutputStream java doc

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -41,6 +41,7 @@ import java.io.OutputStream;
  * The output data format is:
  * <ol>
  * <li>snappy codec header defined in {@link SnappyCodec} (8 bytes)
+ * <li>codec version (4 bytes integer, at least 1) and compatible version (4 bytes integer)
  * <li>compressed block 1 : a pair of (compressed data size [4 byte integer.
  * Big-endian], compressed data...)
  * <li>compressed block 2


### PR DESCRIPTION
Add more information about output data format.

besides writing the snappy magic header (8 bytes) described in
```
new byte[] {-126, 'S', 'N', 'A', 'P', 'P', 'Y', 0}
```
We also need to write another 8 bytes: 2 integers each with 4 bytes representing version and compatible version. The version should at least be 1.
---- I think the above information should be added to the SnappyOutputStream.

See #205 