### PR TITLE
Add OSGi bundle metadata to manifest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,10 +109,13 @@ libraryDependencies ++= Seq(
 
 enablePlugins(SbtOsgi)
 
+osgiSettings
+
 OsgiKeys.exportPackage := Seq("org.xerial.snappy", "org.xerial.snappy.buffer")
 OsgiKeys.bundleSymbolicName := "org.xerial.snappy.snappy-java"
 OsgiKeys.bundleActivator := Option("org.xerial.snappy.SnappyBundleActivator")
 OsgiKeys.importPackage := Seq("""org.osgi.framework;version="[1.5,2)"""")
+OsgiKeys.requireCapability := """osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))""""
 
 OsgiKeys.additionalHeaders := Map(
   "Bundle-NativeCode" -> Seq(
@@ -128,7 +131,7 @@ OsgiKeys.additionalHeaders := Map(
     "org/xerial/snappy/native/Linux/x86/libsnappyjava.so;osname=linux;processor=x86",
     "org/xerial/snappy/native/Linux/aarch64/libsnappyjava.so;osname=linux;processor=aarch64",
     "org/xerial/snappy/native/Linux/arm/libsnappyjava.so;osname=linux;processor=arm",
-    "org/xerial/snappy/native/Linux/arm7/libsnappyjava.so;osname=linux;processor=arm_le",
+    "org/xerial/snappy/native/Linux/armv7/libsnappyjava.so;osname=linux;processor=arm_le",
     "org/xerial/snappy/native/Linux/ppc64/libsnappyjava.so;osname=linux;processor=ppc64le",
     "org/xerial/snappy/native/Linux/s390x/libsnappyjava.so;osname=linux;processor=s390x",
     "org/xerial/snappy/native/AIX/ppc/libsnappyjava.a;osname=aix;processor=ppc",


### PR DESCRIPTION
Fixes #210

`osgiSettings` is apparently required, per sbt-osgi docs:

> To also override the default publish behaviour, also add the osgiSettings settings to your project via your preferred method.

Also I noticed that the version of sbt-osgi used now includes a 'Require-Capability' section to the manifest.  The default behavior of OSGi is to use the version of java you are compiling the project with, i.e.:

> Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"

Since the project works with java 1.7, I added an explicit entry for 1.7.

Finally I noticed that the path to the libsnappyjava.so library for `arm_le` was incorrect, it should be `armv7` instead of `arm7`

Example of manifest generated:

```
Manifest-Version: 1.0                                                                                                                                                                                                               
Bnd-LastModified: 1519422103947
Bundle-ActivationPolicy: lazy
Bundle-Activator: org.xerial.snappy.SnappyBundleActivator
Bundle-Description: snappy-java: A fast compression/decompression librar
 y
Bundle-DocURL: http://www.xerial.org/
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: snappy-java: A fast compression/decompression library
Bundle-NativeCode: org/xerial/snappy/native/Windows/x86_64/snappyjava.dl
 l;osname=win32;processor=x86-64,org/xerial/snappy/native/Windows/x86_64
 /snappyjava.dll;osname=win32;processor=x64,org/xerial/snappy/native/Win
 dows/x86_64/snappyjava.dll;osname=win32;processor=amd64,org/xerial/snap
 py/native/Windows/x86/snappyjava.dll;osname=win32;processor=x86,org/xer
 ial/snappy/native/Mac/x86/libsnappyjava.jnilib;osname=macosx;processor=
 x86,org/xerial/snappy/native/Mac/x86_64/libsnappyjava.jnilib;osname=mac
 osx;processor=x86-64,org/xerial/snappy/native/Linux/x86_64/libsnappyjav
 a.so;osname=linux;processor=x86-64,org/xerial/snappy/native/Linux/x86_6
 4/libsnappyjava.so;osname=linux;processor=x64,org/xerial/snappy/native/
 Linux/x86_64/libsnappyjava.so;osname=linux;processor=amd64,org/xerial/s
 nappy/native/Linux/x86/libsnappyjava.so;osname=linux;processor=x86,org/
 xerial/snappy/native/Linux/aarch64/libsnappyjava.so;osname=linux;proces
 sor=aarch64,org/xerial/snappy/native/Linux/arm/libsnappyjava.so;osname=
 linux;processor=arm,org/xerial/snappy/native/Linux/armv7/libsnappyjava.
 so;osname=linux;processor=arm_le,org/xerial/snappy/native/Linux/ppc64/l
 ibsnappyjava.so;osname=linux;processor=ppc64le,org/xerial/snappy/native
 /Linux/s390x/libsnappyjava.so;osname=linux;processor=s390x,org/xerial/s
 nappy/native/AIX/ppc/libsnappyjava.a;osname=aix;processor=ppc,org/xeria
 l/snappy/native/AIX/ppc64/libsnappyjava.a;osname=aix;processor=ppc64,or
 g/xerial/snappy/native/SunOS/x86/libsnappyjava.so;osname=sunos;processo
 r=x86,org/xerial/snappy/native/SunOS/x86_64/libsnappyjava.so;osname=sun
 os;processor=x86-64,org/xerial/snappy/native/SunOS/sparc/libsnappyjava.
 so;osname=sunos;processor=sparc
Bundle-SymbolicName: org.xerial.snappy.snappy-java
Bundle-Vendor: xerial.org
Bundle-Version: 1.1.7.2-SNAPSHOT
Created-By: 1.8.0_161 (Oracle Corporation)
Export-Package: org.xerial.snappy;uses:="org.osgi.framework,org.xerial.s
 nappy.buffer";version="1.1.7",org.xerial.snappy.buffer;version="1.1.7"
Import-Package: org.osgi.framework;version="[1.5,2)"
Private-Package: org.xerial.snappy.native.AIX.ppc,org.xerial.snappy.nati
 ve.AIX.ppc64,org.xerial.snappy.native.FreeBSD.x86_64,org.xerial.snappy.
 native.Linux.aarch64,org.xerial.snappy.native.Linux.android-arm,org.xer
 ial.snappy.native.Linux.arm,org.xerial.snappy.native.Linux.armv6,org.xe
 rial.snappy.native.Linux.armv7,org.xerial.snappy.native.Linux.ppc,org.x
 erial.snappy.native.Linux.ppc64,org.xerial.snappy.native.Linux.ppc64le,
 org.xerial.snappy.native.Linux.s390x,org.xerial.snappy.native.Linux.x86
 ,org.xerial.snappy.native.Linux.x86_64,org.xerial.snappy.native.Mac.x86
 ,org.xerial.snappy.native.Mac.x86_64,org.xerial.snappy.native,org.xeria
 l.snappy.native.SunOS.sparc,org.xerial.snappy.native.SunOS.x86,org.xeri
 al.snappy.native.SunOS.x86_64,org.xerial.snappy.native.Windows.x86,org.
 xerial.snappy.native.Windows.x86_64
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
Tool: Bnd-2.4.0.201411031534
```
