### PR TITLE
change snappyOutputStream  writeHeader order to fix when outputStream…

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -369,19 +369,14 @@ public class SnappyOutputStream
             outputCursor = writeHeader();
             headerWritten = true;
         }
-
         if (inputCursor <= 0) {
             return; // no need to dump
         }
-
-
         // Compress and dump the buffer content
         if (!hasSufficientOutputBufferFor(inputCursor)) {
             dumpOutput();
         }
-
         writeBlockPreemble();
-
         int compressedSize = Snappy.compress(inputBuffer, 0, inputCursor, outputBuffer, outputCursor + 4);
         // Write compressed data size
         writeInt(outputBuffer, outputCursor, compressedSize);

--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -365,7 +365,6 @@ public class SnappyOutputStream
     protected void compressInput()
             throws IOException
     {
-        //  generate header
         if (!headerWritten) {
             outputCursor = writeHeader();
             headerWritten = true;
@@ -375,10 +374,6 @@ public class SnappyOutputStream
             return; // no need to dump
         }
 
-//        if (!headerWritten) {
-//            outputCursor = writeHeader();
-//            headerWritten = true;
-//        }
 
         // Compress and dump the buffer content
         if (!hasSufficientOutputBufferFor(inputCursor)) {

--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -365,14 +365,20 @@ public class SnappyOutputStream
     protected void compressInput()
             throws IOException
     {
-        if (inputCursor <= 0) {
-            return; // no need to dump
-        }
-
+        //  generate header
         if (!headerWritten) {
             outputCursor = writeHeader();
             headerWritten = true;
         }
+
+        if (inputCursor <= 0) {
+            return; // no need to dump
+        }
+
+//        if (!headerWritten) {
+//            outputCursor = writeHeader();
+//            headerWritten = true;
+//        }
 
         // Compress and dump the buffer content
         if (!hasSufficientOutputBufferFor(inputCursor)) {


### PR DESCRIPTION
In version 1.1.2.x, SnappyOutputStream will generate a snappy header no matter if it has been written.
But In master branch,  SnappyOutputStream will not generate a header if it has not been written. So to fix it, I change some code in  SnappyOutputStream.java. After fixed it, the code  will have the same behavior in version 1.1.2.x and 1.1.7.x.
```
        ByteArrayOutputStream b = new ByteArrayOutputStream();
        SnappyOutputStream os = new SnappyOutputStream(b);
        os.close();
        int len= b.size();
        assertEquals(16,len);
```