### PR TITLE
Adding s390x support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
 sudo: required
 
+language: scala
+
 matrix:
   include:
     - os: linux
       jdk: openjdk8
-      language: scala
     - os: linux
       jdk: openjdk11
-      language: scala
     - os: linux
       jdk: openjdk11
       arch: s390x
-      language: scala
+      dist: bionic
 
 services:
   - docker
 
 scala:
   - 2.12.8
+
+before_script:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
+      if [ "$TRAVIS_ARCH" = "s390x" ]; then 
+        sudo apt-get install -y openjdk-11-jdk;
+        export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-s390x && export PATH=$JAVA_HOME/bin:$PATH; 
+      fi;
+    fi
 
 script:
   - ./script/travis-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - os: linux
       jdk: openjdk11
       arch: s390x
-      language: java
+      language: scala
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
 sudo: required
 
+matrix:
+  include:
+    - os: linux
+      jdk: openjdk8
+      language: scala
+    - os: linux
+      jdk: openjdk8
+      arch: s390x
+      language: java
+    - os: linux
+      jdk: openjdk11
+      language: scala
+    - os: linux
+      jdk: openjdk11
+      arch: s390x
+      language: java
+
 services:
   - docker
 
-language: scala
-
 scala:
   - 2.12.8
-
-jdk:
-  - openjdk8
-  - openjdk11
 
 script:
   - ./script/travis-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ matrix:
       jdk: openjdk8
       language: scala
     - os: linux
-      jdk: openjdk8
-      arch: s390x
-      language: java
-    - os: linux
       jdk: openjdk11
       language: scala
     - os: linux


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.