### PR TITLE
Add -static-libstdc++ on LINKFLAGS of aarch64

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -232,7 +232,7 @@ Linux-android-arm_SNAPPY_FLAGS:=
 Linux-aarch64_CXX       := $(CROSS_PREFIX)g++
 Linux-aarch64_STRIP     := $(CROSS_PREFIX)strip
 Linux-aarch64_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -O2 -fPIC -fvisibility=hidden
-Linux-aarch64_LINKFLAGS := -shared -static-libgcc
+Linux-aarch64_LINKFLAGS := -shared -static-libgcc -static-libstdc++
 Linux-aarch64_LIBNAME   := libsnappyjava.so
 Linux-aarch64_SNAPPY_FLAGS:=
 


### PR DESCRIPTION
I would like `-static-libstdc++` on LINKFLAGS for aarch64 to fix [BIGTOP-3397](https://issues.apache.org/jira/browse/BIGTOP-3397) (packaging failure of Spark on CentOS 7(aarch64)).
