### PR TITLE
Fix failure of make mac64 due to version mismatch of cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ mac32: jni-header
 	$(MAKE) native OS_NAME=Mac OS_ARCH=x86
 
 mac64: jni-header
-	docker run -it $(DOCKER_RUN_OPTS) -v $$PWD:/workdir -e CROSS_TRIPLE=x86_64-apple-darwin multiarch/crossbuild make clean-native native OS_NAME=Mac OS_ARCH=x86_64
+	docker run -it $(DOCKER_RUN_OPTS) -v $$PWD:/workdir -e CROSS_TRIPLE=x86_64-apple-darwin xerial/crossbuild make clean-native native OS_NAME=Mac OS_ARCH=x86_64
 
 linux32: jni-header
 	docker run $(DOCKER_RUN_OPTS) -ti -v $$PWD:/work xerial/centos5-linux-x86_64-pic bash -c 'make clean-native native-nocmake OS_NAME=Linux OS_ARCH=x86'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,3 +4,6 @@ centos5-image:
 	# dockerhub login
 	# docker login --username=xerial
 	# docker push xerial/centos5-linux-x86_64:latest
+
+multiarch-crossbuild-image:
+	docker build https://github.com/multiarch/crossbuild.git -t xerial/crossbuild:latest


### PR DESCRIPTION
`make mac64` fails as reported in #257 . The cause is version mismatch of cmake.

```
$ make mac64
...
cd target/snappy-1.1.7-Mac-x86_64 && cmake  ../../target/snappy-1.1.7
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.1 or higher is required.  You are running version 3.0.2
```

Using latest multiarch/crossbuild based on Debian stretch should fix this.