### PR TITLE
Fix intinite loop of cmake wrapper of osxcross.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,4 +6,4 @@ centos5-image:
 	# docker push xerial/centos5-linux-x86_64:latest
 
 multiarch-crossbuild-image:
-	docker build https://github.com/multiarch/crossbuild.git -t xerial/crossbuild:latest
+	docker build https://github.com/iwasakims/crossbuild.git#fix-osxcross-cmake -t xerial/crossbuild:latest


### PR DESCRIPTION
I'm submitting the follow-up of #261. We don't need this if https://github.com/multiarch/crossbuild/pull/49 is merged soon.