### PR TITLE
prefer use of java.util.zip.CRC32C

### DIFF
--- a/src/main/java/org/xerial/snappy/PureJavaCrc32C.java
+++ b/src/main/java/org/xerial/snappy/PureJavaCrc32C.java
@@ -48,8 +48,7 @@ public class PureJavaCrc32C
     /** {@inheritDoc} */
     public long getValue()
     {
-        long ret = crc;
-        return (~ret) & 0xffffffffL;
+        return (~crc) & 0xffffffffL;
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/xerial/snappy/SnappyFramedInputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyFramedInputStream.java
@@ -21,6 +21,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
+import java.util.zip.Checksum;
 
 import org.xerial.snappy.pool.BufferPool;
 import org.xerial.snappy.pool.DefaultPoolFactory;
@@ -40,6 +41,7 @@ public final class SnappyFramedInputStream
         ReadableByteChannel
 {
 
+    private final Checksum crc32 = SnappyFramed.getCRC32C();
     private final ReadableByteChannel rbc;
     private final ByteBuffer frameHeader;
     private final boolean verifyChecksums;
@@ -572,7 +574,7 @@ public final class SnappyFramedInputStream
         }
 
         if (verifyChecksums) {
-            final int actualCrc32c = SnappyFramed.maskedCrc32c(buffer,
+            final int actualCrc32c = SnappyFramed.maskedCrc32c(crc32, buffer,
                     position, valid - position);
             if (frameData.checkSum != actualCrc32c) {
                 throw new IOException("Corrupt input: invalid checksum");

--- a/src/main/java/org/xerial/snappy/SnappyFramedOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyFramedOutputStream.java
@@ -17,6 +17,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.zip.Checksum;
 
 import org.xerial.snappy.pool.BufferPool;
 import org.xerial.snappy.pool.DefaultPoolFactory;
@@ -59,6 +60,7 @@ public final class SnappyFramedOutputStream
      */
     public static final double DEFAULT_MIN_COMPRESSION_RATIO = 0.85d;
 
+    private final Checksum crc32 = SnappyFramed.getCRC32C();
     private final ByteBuffer headerBuffer = ByteBuffer.allocate(8).order(
             ByteOrder.LITTLE_ENDIAN);
     private final BufferPool bufferPool;
@@ -503,7 +505,7 @@ public final class SnappyFramedOutputStream
         final int length = buffer.remaining();
 
         // crc is based on the user supplied input data
-        final int crc32c = maskedCrc32c(input, 0, length);
+        final int crc32c = maskedCrc32c(crc32, input, 0, length);
 
         directInputBuffer.clear();
         directInputBuffer.put(buffer);

--- a/src/test/java/org/xerial/snappy/SnappyFramedStreamTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyFramedStreamTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.fail;
 import static org.xerial.snappy.SnappyFramed.COMPRESSED_DATA_FLAG;
 import static org.xerial.snappy.SnappyFramed.HEADER_BYTES;
 import static org.xerial.snappy.SnappyFramed.UNCOMPRESSED_DATA_FLAG;
-import static org.xerial.snappy.SnappyFramed.maskedCrc32c;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -417,5 +416,10 @@ public class SnappyFramedStreamTest
         byte[] random = Arrays.copyOf(gen.data, length);
         assertEquals(random.length, length);
         return random;
+    }
+
+    public static int maskedCrc32c(byte[] data)
+    {
+        return SnappyFramed.maskedCrc32c(new PureJavaCrc32C(), data, 0, data.length);
     }
 }


### PR DESCRIPTION
java 9 introduced a jre implementation of crc32: https://docs.oracle.com/javase/9/docs/api/java/util/zip/CRC32C.html
The hotspot jvm also includes intrinsics for native optimizations. According to this issue[1], as long as you are on a recent version (last 2 years), the non-intrinsified implementation is ~2x faster than the hadoop pure java implementation (which is what PureJavaCrc32C is based on). The intrinsified implementation is another 2-3x faster than that.

[1] - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8191328