### PR TITLE
Adding ppc64le support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ os: linux
 
 arch:
   - s390x
+  - ppc64le
 
 script:
 #  - sudo apt-get install -y openjdk-11-jdk;


### PR DESCRIPTION
Adding support for IBM Power arch (ppc64le) in Travis which is supported natively on Power.