### PR TITLE
Fixes xerial/snappy-java#326 Add option to disable fallback to PureJa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A file `target/snappy-java-$(version).jar` is the product additionally containin
 ### Using pure-java Snappy implementation
 
 snappy-java can optionally use a pure-java implementation of Snappy based on [aircompressor](https://github.com/airlift/aircompressor/tree/master/src/main/java/io/airlift/compress/snappy). This implementation is selected when no native Snappy library for your platform is found. You can also force using this pure-java implementation by setting a JVM property `org.xerial.snappy.purejava=true` before loading any class of Snappy (e.g., using `-Dorg.xerial.snappy.purejava=true` option when launching JVM).
-
+The pure-java implementation is also used as a fallback when no native Snappy library can be loaded. You can disable this fallback by setting the JVM property `org.xerial.snappy.purejava.fallback=false`
 
 ### Using snappy-java with Tomcat 6 (or higher) Web Server
 

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ crossPaths := false
 
 libraryDependencies ++= Seq(
   "junit"               % "junit"              % "4.13.2"  % "test",
+  "org.mockito"         % "mockito-inline"     % "4.6.1"   % "test",
   "org.codehaus.plexus" % "plexus-classworlds" % "2.4"     % "test",
   "org.xerial.java"     % "xerial-core"        % "2.1"     % "test",
   "org.wvlet.airframe" %% "airframe-log"       % "21.12.1" % "test",

--- a/src/main/java/org/xerial/snappy/SnappyLoader.java
+++ b/src/main/java/org/xerial/snappy/SnappyLoader.java
@@ -78,6 +78,7 @@ public class SnappyLoader
     public static final String KEY_SNAPPY_LIB_PATH = "org.xerial.snappy.lib.path";
     public static final String KEY_SNAPPY_LIB_NAME = "org.xerial.snappy.lib.name";
     public static final String KEY_SNAPPY_PUREJAVA = "org.xerial.snappy.purejava";
+    public static final String KEY_SNAPPY_PUREJAVA_FALLBACK = "org.xerial.snappy.purejava.fallback";
     public static final String KEY_SNAPPY_TEMPDIR = "org.xerial.snappy.tempdir";
     public static final String KEY_SNAPPY_USE_SYSTEMLIB = "org.xerial.snappy.use.systemlib";
     public static final String KEY_SNAPPY_DISABLE_BUNDLED_LIBS = "org.xerial.snappy.disable.bundled.libs"; // Depreciated, but preserved for backward compatibility
@@ -170,7 +171,11 @@ public class SnappyLoader
         }
         catch(Throwable e) {
             // Fall-back to pure-java Snappy implementation
-            setSnappyApi(new PureJavaSnappy());
+            if(Boolean.parseBoolean(System.getProperty(KEY_SNAPPY_PUREJAVA_FALLBACK, "true"))) {
+                setSnappyApi(new PureJavaSnappy());
+            } else {
+                throw e;
+            }
         }
         return snappyApi;
     }
@@ -188,7 +193,8 @@ public class SnappyLoader
     /**
      * Load a native library of snappy-java
      */
-    private synchronized static void loadNativeLibrary()
+    // VisibleForTesting
+    static synchronized void loadNativeLibrary()
     {
         if (!isLoaded) {
             try {


### PR DESCRIPTION
A new option was added (system property org.xerial.snappy.purejava.fallback, default=true (backwards compatibility)) that checks if `loadSnappyApi` should fallback to PureJavaSnappy or re-throw the Throwable if the native library could not be loaded.