### PR TITLE
Fixes #326 Add option to disable fallback to PureJavaSnappy + doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A file `target/snappy-java-$(version).jar` is the product additionally containin
 ### Using pure-java Snappy implementation
 
 snappy-java can optionally use a pure-java implementation of Snappy based on [aircompressor](https://github.com/airlift/aircompressor/tree/master/src/main/java/io/airlift/compress/snappy). This implementation is selected when no native Snappy library for your platform is found. You can also force using this pure-java implementation by setting a JVM property `org.xerial.snappy.purejava=true` before loading any class of Snappy (e.g., using `-Dorg.xerial.snappy.purejava=true` option when launching JVM).
-
+The pure-java implementation is also used as a fallback when no native Snappy library can be loaded. You can disable this fallback by setting the JVM property `org.xerial.snappy.purejava.fallback=false`
 
 ### Using snappy-java with Tomcat 6 (or higher) Web Server
 

--- a/src/main/java/org/xerial/snappy/SnappyLoader.java
+++ b/src/main/java/org/xerial/snappy/SnappyLoader.java
@@ -78,6 +78,7 @@ public class SnappyLoader
     public static final String KEY_SNAPPY_LIB_PATH = "org.xerial.snappy.lib.path";
     public static final String KEY_SNAPPY_LIB_NAME = "org.xerial.snappy.lib.name";
     public static final String KEY_SNAPPY_PUREJAVA = "org.xerial.snappy.purejava";
+    public static final String KEY_SNAPPY_PUREJAVA_FALLBACK = "org.xerial.snappy.purejava.fallback";
     public static final String KEY_SNAPPY_TEMPDIR = "org.xerial.snappy.tempdir";
     public static final String KEY_SNAPPY_USE_SYSTEMLIB = "org.xerial.snappy.use.systemlib";
     public static final String KEY_SNAPPY_DISABLE_BUNDLED_LIBS = "org.xerial.snappy.disable.bundled.libs"; // Depreciated, but preserved for backward compatibility
@@ -170,7 +171,11 @@ public class SnappyLoader
         }
         catch(Throwable e) {
             // Fall-back to pure-java Snappy implementation
-            setSnappyApi(new PureJavaSnappy());
+            if(Boolean.parseBoolean(System.getProperty(KEY_SNAPPY_PUREJAVA_FALLBACK, "true"))) {
+                setSnappyApi(new PureJavaSnappy());
+            } else {
+                throw e;
+            }
         }
         return snappyApi;
     }


### PR DESCRIPTION
Adds a simple if condition to disable the fallback to PureJavaSnappy and re-throws the exception if the system property org.xerial.snappy.purejava.fallback is set to false (default value is true to ensure backwards compatibility).