### PR TITLE
CI Fix to Prevent Checks Dealing with Large Array Sizes

### DIFF
--- a/src/test/java/org/xerial/snappy/SnappyTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyTest.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.junit.Assume;
 import org.junit.Assert;
 import org.junit.Test;
 import org.xerial.util.log.Logger;
@@ -415,31 +416,37 @@ public class SnappyTest
      */
     @Test(expected = SnappyError.class)
     public void isTooLargeDoubleArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new double[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeCharArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new char[Integer.MAX_VALUE / 2 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeFloatArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeIntArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new int[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeLongArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new long[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeShortArrayInputLength() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         Snappy.compress(new short[Integer.MAX_VALUE / 2 + 1]);
     }
 
@@ -474,26 +481,31 @@ public class SnappyTest
      */
     @Test(expected = SnappyError.class)
     public void isTooLargeDoubleArrayInputLengthForBitShuffleShuffle() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         BitShuffle.shuffle(new double[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeFloatArrayInputLengthForBitShuffleShuffle() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         BitShuffle.shuffle(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeIntArrayInputLengthForBitShuffleShuffle() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         BitShuffle.shuffle(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeLongArrayInputLengthForBitShuffleShuffle() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         BitShuffle.shuffle(new long[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeShortArrayInputLengthForBitShuffleShuffle() throws Exception {
+        Assume.assumeTrue(System.getenv("CI").equals("true"));
         BitShuffle.shuffle(new short[Integer.MAX_VALUE / 2 + 1]);
 
 

--- a/src/test/java/org/xerial/snappy/SnappyTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyTest.java
@@ -510,6 +510,7 @@ public class SnappyTest
     }
 
     private void assumingCIIsFalse() {
+        if (System.getenv("CI") == null) return;
         Assume.assumeTrue(System.getenv("CI").equals("false"));
     }
 }

--- a/src/test/java/org/xerial/snappy/SnappyTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyTest.java
@@ -416,37 +416,37 @@ public class SnappyTest
      */
     @Test(expected = SnappyError.class)
     public void isTooLargeDoubleArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new double[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeCharArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new char[Integer.MAX_VALUE / 2 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeFloatArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeIntArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new int[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeLongArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new long[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeShortArrayInputLength() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         Snappy.compress(new short[Integer.MAX_VALUE / 2 + 1]);
     }
 
@@ -481,33 +481,35 @@ public class SnappyTest
      */
     @Test(expected = SnappyError.class)
     public void isTooLargeDoubleArrayInputLengthForBitShuffleShuffle() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         BitShuffle.shuffle(new double[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeFloatArrayInputLengthForBitShuffleShuffle() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         BitShuffle.shuffle(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeIntArrayInputLengthForBitShuffleShuffle() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         BitShuffle.shuffle(new float[Integer.MAX_VALUE / 4 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeLongArrayInputLengthForBitShuffleShuffle() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         BitShuffle.shuffle(new long[Integer.MAX_VALUE / 8 + 1]);
     }
 
     @Test(expected = SnappyError.class)
     public void isTooLargeShortArrayInputLengthForBitShuffleShuffle() throws Exception {
-        Assume.assumeTrue(System.getenv("CI").equals("true"));
+        assumingCIIsFalse();
         BitShuffle.shuffle(new short[Integer.MAX_VALUE / 2 + 1]);
+    }
 
-
+    private void assumingCIIsFalse() {
+        Assume.assumeTrue(System.getenv("CI").equals("false"));
     }
 }

--- a/src/test/java/org/xerial/snappy/SnappyTest.java
+++ b/src/test/java/org/xerial/snappy/SnappyTest.java
@@ -510,7 +510,8 @@ public class SnappyTest
     }
 
     private void assumingCIIsFalse() {
-        if (System.getenv("CI") == null) return;
-        Assume.assumeTrue(System.getenv("CI").equals("false"));
+        if (System.getenv("CI") == null)
+            return;
+        Assume.assumeFalse("Skipped on CI", System.getenv("CI").equals("true"));
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updating SnappyTest.java and ignoring checks with arrays of large sizes.

### Why are the changes needed?
To prevent java.lang.OutOfMemory errors from being caught during GitHub checks.

### How was this patch tested?
SnappyTest.java