### PR TITLE
Update libsnappy.so for s390x

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -173,7 +173,7 @@ Linux-s390_SNAPPY_FLAGS  :=
 Linux-s390x_CXX       := $(CROSS_PREFIX)g++
 Linux-s390x_STRIP     := $(CROSS_PREFIX)strip
 ifeq ($(IBM_JDK_7),)
-  Linux-s390x_CXXFLAGS  := -Ilib/inc_linux -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 -std=c++11
+  Linux-s390x_CXXFLAGS  := -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -fvisibility=hidden -m64 -std=c++11
 else
   Linux-s390x_CXXFLAGS  := -I$(JAVA_HOME)/include/linux -Ilib/inc_ibm -I$(JAVA_HOME)/include -Ilib/inc_mac -O2 -fPIC -m64 -std=c++11
 endif


### PR DESCRIPTION
@xerial observed an issue with the latest libsnappy.so file published with docker cross steps. When `lib/inc_linux/config.h` is included in s390x builds, the generated libsnappy.so fails to uncompress. This PR is for fixing the same. 
Wanted to confirm if this PR is merged, native-all (or linux-s390x) target will update native libraries to be included in next version jar, correct?