### PR TITLE
Fix the `GLIBC_2.32 not found` issue of `libsnappyjava.so` in certain Linux distributions on s390x

### DIFF
--- a/docker/dockcross-s390x
+++ b/docker/dockcross-s390x
@@ -1,5 +1,5 @@
 #!/bin/bash
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-s390x
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-s390x:20210210-84c47e5
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
The `dockcross/linux-s390x:latest` docker image is currently used to cross compile the native library and the target lowest GLIBC version supported in the toolchain is v2.32. Hence, the version `GLIBC_2.32` not found issue would occur when the built s390x `libsnappyjava.so` was invoked in Linux distributions whose GLIBC version is lower than v2.32, such as RHEL (7, 8), SLES (12, 15) and Ubuntu 20.04.
 
This PR changed the `dockcross/linux-s390x` docker image to an earlier tag `20210210-84c47e5` in which the cross-compile toolchain is compatible with GLIBC v2.17, thus the built native library could work on the above-mentioned distributions, as well as newer distributions such as RHEL 9 or Ubuntu 22.04.

Fixes: https://github.com/xerial/snappy-java/issues/464