### PR TITLE
Use matrix build for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,67 +31,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: scalafmt test
         run: ./sbt scalafmtCheckAll
-  test:
-    name: test jdk11
+  test-jdk:
+    strategy:
+      matrix:
+        version: [ '8', '11', '17', '21' ]
+    name: test jdk${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: ${{ matrix.version }}
       - uses: actions/cache@v3
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-jdk11-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk11-
-      - name: Test
-        run: ./sbt test
-  test_jdk8:
-    name: test jdk8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '8'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk8-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk8-
-      - name: Test
-        run: ./sbt test
-  test_jdk17:
-    name: test jdk17
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '17'
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-jdk17-${{ hashFiles('**/*.sbt') }}
-        restore-keys: ${{ runner.os }}-jdk17-
-    - name: Test
-      run: ./sbt test
-  test_jdk21:
-    name: test jdk21
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '21'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk21-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk21-
+          key: ${{ runner.os }}-jdk${{ matrix.version }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk${{ matrix.version }}-
       - name: Test
         run: ./sbt test


### PR DESCRIPTION
Simplifies workflow file, by using a matrix build
instead of separate build jobs with same steps.