### PR TITLE
Fix SnappyOutputStream write() Length Check for 31-bit Integer Limit

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -119,6 +119,13 @@ public class SnappyOutputStream
         if (closed) {
             throw new IOException("Stream is closed");
         }
+
+        //Check length
+        assert byteLength <= b.length : "length parameter exceeds array size";
+
+        //check 31 bit integer limit
+        assert byteLength <= Integer.MAX_VALUE : "length parameter exceeds 31-bit integer limit";
+        
         int cursor = 0;
         while (cursor < byteLength) {
             int readLen = Math.min(byteLength - cursor, blockSize - inputCursor);

--- a/src/main/java/org/xerial/snappy/SnappyOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyOutputStream.java
@@ -121,10 +121,10 @@ public class SnappyOutputStream
         }
 
         //Check length
-        assert byteLength <= b.length : "length parameter exceeds array size";
+        assert (byteLength <= b.length) : "length parameter exceeds array size";
 
         //check 31 bit integer limit
-        assert byteLength <= Integer.MAX_VALUE : "length parameter exceeds 31-bit integer limit";
+        assert (byteLength <= Integer.MAX_VALUE) : "length parameter exceeds 31-bit integer limit";
         
         int cursor = 0;
         while (cursor < byteLength) {


### PR DESCRIPTION
https://github.com/xerial/snappy-java/issues/513