### PR TITLE
Fix javadoc links to new url for framing_format.txt

### DIFF
--- a/src/main/java/org/xerial/snappy/SnappyFramedInputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyFramedInputStream.java
@@ -28,7 +28,7 @@ import org.xerial.snappy.pool.DefaultPoolFactory;
 
 /**
  * Implements the <a
- * href="http://snappy.googlecode.com/svn/trunk/framing_format.txt"
+ * href="https://github.com/google/snappy/blob/main/framing_format.txt"
  * >x-snappy-framed</a> as an {@link InputStream} and
  * {@link ReadableByteChannel}.
  *

--- a/src/main/java/org/xerial/snappy/SnappyFramedOutputStream.java
+++ b/src/main/java/org/xerial/snappy/SnappyFramedOutputStream.java
@@ -24,7 +24,7 @@ import org.xerial.snappy.pool.DefaultPoolFactory;
 
 /**
  * Implements the <a
- * href="http://snappy.googlecode.com/svn/trunk/framing_format.txt"
+ * href="https://github.com/google/snappy/blob/main/framing_format.txt"
  * >x-snappy-framed</a> as an {@link OutputStream} and
  * {@link WritableByteChannel}.
  *


### PR DESCRIPTION
Tiny PR to fix the links in the Javadoc for `SnappyFramedInputStream` and `SnappyFramedOutputStream` which point to the old SVN location for the Snappy project on `googlecode` instead of the current Git repo location on GitHub.
