### PR TITLE
feat: add GraalVM support

### DIFF
--- a/src/main/resources/META-INF/native-image/org.xerial.snappy/snappy-java/resource-config.json
+++ b/src/main/resources/META-INF/native-image/org.xerial.snappy/snappy-java/resource-config.json
@@ -1,0 +1,11 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern":".*libsnappyjava.dylib"},
+      {"pattern":".*libsnappyjava.so"},
+      {"pattern":".*libsnappyjava.dll"},
+      {"pattern":".*libsnappyjava.a"}
+    ]
+  },
+  "bundles": []
+}


### PR DESCRIPTION
This PR adds GraalVM support to `snappy-java`

Documentation references:
* Accessing Resources in Native Image: https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Resources/
* Native Image Build Configuration: https://www.graalvm.org/latest/reference-manual/native-image/overview/BuildConfiguration/
* Example implementation - AWS CRT: https://github.com/awslabs/aws-crt-java/pull/749

I added the files to this specific folder as it is going to be picked up by GraalVM automatically so you don't have to use `-H:ResourceConfigurationResources` - see the last comments of the "Example implementation" and the link of "Native image Build Configuration"

There are no `native-image.properties` required.

Fixes: https://github.com/xerial/snappy-java/issues/429