### PR TITLE
the dll is called snappyjava not libsnappyjava

### DIFF
--- a/src/main/resources/META-INF/native-image/org.xerial.snappy/snappy-java/resource-config.json
+++ b/src/main/resources/META-INF/native-image/org.xerial.snappy/snappy-java/resource-config.json
@@ -3,7 +3,7 @@
     "includes": [
       {"pattern":".*libsnappyjava.dylib"},
       {"pattern":".*libsnappyjava.so"},
-      {"pattern":".*libsnappyjava.dll"},
+      {"pattern":".*snappyjava.dll"},
       {"pattern":".*libsnappyjava.a"}
     ]
   },


### PR DESCRIPTION
Hi!

I found an issue generating a native-image with graalvm. It seems for windows there's no native library included.

```
Error: Exception in thread "main" org.xerial.snappy.SnappyError: [FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Windows and os.arch=x86_64
	at org.xerial.snappy.SnappyLoader.findNativeLibrary(SnappyLoader.java:345)
	at org.xerial.snappy.SnappyLoader.loadNativeLibrary(SnappyLoader.java:179)
	at org.xerial.snappy.SnappyLoader.loadSnappyApi(SnappyLoader.java:157)
	at org.xerial.snappy.Snappy.init(Snappy.java:70)
	at org.xerial.snappy.Snappy.<clinit>(Snappy.java:47)
	at org.apache.parquet.hadoop.codec.SnappyDecompressor.maxUncompressedLength(SnappyDecompressor.java:34)
	at org.apache.parquet.hadoop.codec.NonBlockedDecompressor.decompress(NonBlockedDecompressor.java:72)
	at org.apache.parquet.hadoop.codec.NonBlockedDecompressorStream.read(NonBlockedDecompressorStream.java:51)
```

I found that the `resource-config.json` has a incorrect pattern for windows dlls. The name is `snappyjava` not `libsnappyjava`.  So, this is the fix.

I tried the fix in my local and it works.

Regards!
