### PR TITLE
OSInfo: Update link to Java bug #8005545

### DIFF
--- a/src/main/java/org/xerial/snappy/OSInfo.java
+++ b/src/main/java/org/xerial/snappy/OSInfo.java
@@ -176,7 +176,7 @@ public class OSInfo {
             }
 
             // Java 1.8 introduces a system property to determine armel or armhf
-            // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8005545
+            // https://bugs.openjdk.org/browse/JDK-8005545
             String abi = System.getProperty("sun.arch.abi");
             if(abi != null && abi.startsWith("gnueabihf")) {
                 return "armv7";


### PR DESCRIPTION
In a comment, update the link to Java bug #8005545, as the current one leads to a webpage saying: "This bug is not available."