### PR TITLE
Replace setup-scala with setup-java in CI workflows

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,9 +24,10 @@ jobs:
           fetch-depth: 10000
        # Fetch all tags so that sbt-dynver can find the previous release version
       - run: git fetch --tags
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: 'zulu'
+          java-version: '11'
       - uses: actions/cache@v4
         with:
           path: ~/.cache


### PR DESCRIPTION
## Summary
- Replace `olafurpg/setup-scala@v14` with `actions/setup-java@v4` in snapshot workflow
- Use Zulu OpenJDK distribution for consistency with other workflows
- Maintain Java 11 version requirement

## Benefits
- Better consistency across CI workflows (test.yml and release.yml already use setup-java)
- Use officially maintained GitHub Action
- Cleaner configuration with explicit distribution choice

🤖 Generated with [Claude Code](https://claude.ai/code)