### PR TITLE
Update scalafmt configuration for Scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,16 @@
 version = 3.9.4
-runner.dialect = scala213source3
-maxColumn = 180
+project.layout = StandardConvention
+runner.dialect = scala3
+maxColumn = 100
 style = defaultWithAlign
-optIn.breaksInsideChains = true
+docstrings.blankFirstLine = yes
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+rewrite.scala3.insertEndMarkerMinLines = 30
+# Add a new line before case class
+newlines.topLevelStatementBlankLines = [
+  {
+    blanks { after = 1 }
+  }
+]
+newlines.source = unfold


### PR DESCRIPTION
## Summary
- Update scalafmt configuration to properly support Scala 3
- Change runner dialect from `scala213source3` to `scala3`
- Add `StandardConvention` project layout for better organization
- Reduce maxColumn from 180 to 100 for improved code readability
- Add Scala 3 specific rewrite rules for modern syntax conversion
- Configure newlines and docstring formatting for consistent style

## Changes
- **Dialect**: Updated from `scala213source3` to `scala3` to properly support Scala 3.7.1
- **Layout**: Added `StandardConvention` project layout
- **Line length**: Reduced from 180 to 100 characters for better readability
- **Scala 3 features**: Added rewrite rules for new syntax, optional braces removal, and end markers
- **Formatting**: Enhanced newlines and docstring configuration

## Test plan
- [x] Update .scalafmt.conf with new configuration
- [x] Verify scalafmt check passes with new configuration
- [x] Ensure all tests continue to pass
- [x] Confirm build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)