### PR TITLE
chore: update CI workflows to use main branch instead of master

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
       - main
     paths:
       - 'src/main/resources/org/xerial/snappy/VERSION'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,7 +3,7 @@ name: Snapshot Release
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.scala'
       - '**.java'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
 
 jobs:


### PR DESCRIPTION
## Summary
- Updated GitHub Actions workflow files to use `main` branch instead of `master`
- Removed redundant `master` branch references from CI configuration

## Changes
- `.github/workflows/build-native.yml`: Removed master branch from push triggers
- `.github/workflows/snapshot.yml`: Changed master to main for push triggers  
- `.github/workflows/test.yml`: Removed master branch from push triggers

## Test plan
- [ ] Verify CI workflows trigger correctly on main branch pushes
- [ ] Confirm no workflow runs are triggered for master branch

🤖 Generated with [Claude Code](https://claude.ai/code)