### PR TITLE
chore: update release CI to use Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
           fetch-depth: 10000
       # Fetch all tags so that sbt-dynver can find the previous release version
       - run: git fetch --tags -f
-      # Install OpenJDK 11
+      # Install OpenJDK 21
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '21'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '21'
       - uses: actions/cache@v4
         with:
           path: ~/.cache


### PR DESCRIPTION
## Summary
- Updated release.yml workflow to use Java 21 instead of Java 11
- Updated snapshot.yml workflow to use Java 21 instead of Java 11
- Ensures releases and snapshots are built with a more recent Java version

## Test plan
- [ ] CI workflows run successfully with Java 21
- [ ] Release artifacts are properly signed and published
- [ ] Snapshot builds complete without errors

🤖 Generated with [Claude Code](https://claude.ai/code)