### PR TITLE
Suppress AccessController deprecation warning for Java 17+

### DIFF
--- a/src/main/java/org/xerial/snappy/pool/DirectByteBuffers.java
+++ b/src/main/java/org/xerial/snappy/pool/DirectByteBuffers.java
@@ -20,6 +20,7 @@ import java.util.logging.Logger;
 /**
  * Utility to facilitate disposing of direct byte buffer instances.
  */
+@SuppressWarnings("removal")  // AccessController is deprecated for removal in Java 17+
 final class DirectByteBuffers {
 
     /**

--- a/src/main/java/org/xerial/snappy/pool/DirectByteBuffers.java
+++ b/src/main/java/org/xerial/snappy/pool/DirectByteBuffers.java
@@ -20,7 +20,6 @@ import java.util.logging.Logger;
 /**
  * Utility to facilitate disposing of direct byte buffer instances.
  */
-@SuppressWarnings("removal")  // AccessController is deprecated for removal in Java 17+
 final class DirectByteBuffers {
 
     /**
@@ -36,6 +35,7 @@ final class DirectByteBuffers {
         // and https://github.com/apache/lucene-solr/blob/7e03427fa14a024ce257babcb8362d2451941e21/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
         MethodHandle cleanHandle = null;
         try {
+            @SuppressWarnings("removal")  // AccessController is deprecated for removal in Java 17+
             final PrivilegedExceptionAction<MethodHandle> action = new PrivilegedExceptionAction<MethodHandle>() {
 
                 @Override
@@ -91,7 +91,9 @@ final class DirectByteBuffers {
                 }
             };
 
-            cleanHandle = AccessController.doPrivileged(action);
+            @SuppressWarnings("removal")  // AccessController is deprecated for removal in Java 17+
+            MethodHandle temp = AccessController.doPrivileged(action);
+            cleanHandle = temp;
 
         } catch (Throwable t) {
             Logger.getLogger(DirectByteBuffers.class.getName()).log(Level.FINE, "Exception occurred attempting to lookup Sun specific DirectByteBuffer cleaner classes.", t);
@@ -122,6 +124,7 @@ final class DirectByteBuffers {
      *
      * @param buffer The {@code ByteBuffer} to release. Must not be {@code null}. Must be  {@link ByteBuffer#isDirect() direct}.
      */
+    @SuppressWarnings("removal")  // AccessController is deprecated for removal in Java 17+
     public static void releaseDirectByteBuffer(final ByteBuffer buffer)
     {
         assert buffer != null && buffer.isDirect();


### PR DESCRIPTION
## Summary
- Suppresses the deprecation warning for `java.security.AccessController` that appears when compiling with Java 17+
- Adds `@SuppressWarnings("removal")` annotation to the `DirectByteBuffers` class

## Background
`java.security.AccessController` was deprecated for removal in Java 17 as part of [JEP 411](https://openjdk.org/jeps/411) (Deprecate the Security Manager for Removal). This causes the following warning during compilation:

```
[warn] java.security.AccessController in java.security has been deprecated and marked for removal
```

## Solution
Since snappy-java needs to maintain compatibility with Java 8+ (as configured in `build.sbt`), we cannot remove the `AccessController.doPrivileged` calls. The best approach is to suppress the warning while maintaining backward compatibility.

The `AccessController` calls in this class are used to bypass SecurityManager restrictions when cleaning DirectByteBuffers. In Java 17+, these calls effectively just run the action directly since SecurityManager is being phased out.

## Test plan
- [x] Verified compilation succeeds without the AccessController warning
- [x] Existing tests continue to pass
- [x] Code remains compatible with Java 8+

🤖 Generated with [Claude Code](https://claude.ai/code)