### PR TITLE
Adding automatic module name header (#713)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,8 @@ libraryDependencies ++=
       ("org.xerial.snappy", "snappy-java")
   )
 
+packageOptions += Package.ManifestAttributes("Automatic-Module-Name" -> "org.xerial.snappy")
+
 enablePlugins(SbtOsgi)
 
 osgiSettings


### PR DESCRIPTION
Hey @xerial, this change adds an automatic module name header to the JAR manifest, i.e. when using snappy-java as an automatic module with a modularized Java application (JPMS), `org.xerial.snappy` is going to be its module name. By defining this name, other libraries depending on snappy-java can be distributed as JPMS modules to Maven Central.

I have successfully tested using snappy-java in a modularized Java application, using the name defined in the header.