### PR TITLE
Add fuzzing targets for snappy-java

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,32 @@
+name: CIFuzz
+on: [pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'snappy-java'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'snappy-java'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v4
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -42,7 +42,7 @@ public class BitShuffleFuzzer {
       result = BitShuffle.unshuffleIntArray(uncompressed);
     }
     catch( IOException e ){
-      return;
+      throw new RuntimeException(e);
     }
     
     if(Arrays.equals(original,result) == false)

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -17,80 +17,68 @@
 package org.xerial.snappy.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.BitShuffle;
 import java.io.IOException;
 import java.util.Arrays;
 
-
 public class BitShuffleFuzzer {
+  private static final int SIZE = 4096;
+
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    int SIZE = 4096;
-    fuzz_bitshuffle_ints(data.consumeInts(SIZE));
-    fuzz_bitshuffle_longs(data.consumeLongs(SIZE));
-    fuzz_bitshuffle_shorts(data.consumeShorts(SIZE));
+    fuzzBitshuffleInts(data.consumeInts(SIZE));
+    fuzzBitshuffleLongs(data.consumeLongs(SIZE));
+    fuzzBitshuffleShorts(data.consumeShorts(SIZE));
   }
 
-  static void fuzzBitshuffleInts(int[] original){
+  static void fuzzBitshuffleInts(int[] original) {
     int[] result;
 
-    try{   
+    try {
       byte[] shuffledByteArray = BitShuffle.shuffle(original);
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
       result = BitShuffle.unshuffleIntArray(uncompressed);
-    }
-    catch( IOException e ){
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    
-    if(Arrays.equals(original,result) == false)
-    {
+
+    if (!Arrays.equals(original, result)) {
       throw new IllegalStateException("Original and uncompressed data are different");
     }
+  }
 
-  }//fuzz_bitshuffle_ints
-
-  static void fuzz_bitshuffle_longs(long[] original){
+  static void fuzzBitshuffleLongs(long[] original) {
     long[] result;
 
-    try{   
+    try {
       byte[] shuffledByteArray = BitShuffle.shuffle(original);
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
       result = BitShuffle.unshuffleLongArray(uncompressed);
-    }
-    catch( IOException e ){
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    
-    if(Arrays.equals(original,result) == false)
-    {
+
+    if (!Arrays.equals(original, result)) {
       throw new IllegalStateException("Original and uncompressed data are different");
     }
+  }
 
-  }//fuzz_bitshuffle_longs
-
-  static void fuzz_bitshuffle_shorts(short[] original){
+  static void fuzzBitshuffleShorts(short[] original) {
     short[] result;
 
-    try{   
+    try {
       byte[] shuffledByteArray = BitShuffle.shuffle(original);
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
       result = BitShuffle.unshuffleShortArray(uncompressed);
-    }
-    catch( IOException e ){
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    
-    if(Arrays.equals(original,result) == false)
-    {
+
+    if (!Arrays.equals(original, result)) {
       throw new IllegalStateException("Original and uncompressed data are different");
     }
-
-  }//fuzz_bitshuffle_shorts  
-
+  }
 }
-

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -19,8 +19,7 @@ package org.xerial.snappy.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.BitShuffle;
-import java.util.Arrays;
-import java.util.function.Function;
+import java.util.Objects;
 
 public class BitShuffleFuzzer {
   private static final int SIZE = 4096;
@@ -29,11 +28,6 @@ public class BitShuffleFuzzer {
     fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
     fuzzBitshuffle(data.consumeLongs(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "long[]");
     fuzzBitshuffle(data.consumeShorts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "short[]");
-  }
-
-  @FunctionalInterface
-  private interface ExceptionRunnable {
-    void run() throws Exception;
   }
 
   @FunctionalInterface
@@ -52,7 +46,7 @@ public class BitShuffleFuzzer {
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
       T result = unshuffle.apply(uncompressed);
-      if (!Arrays.equals((Object[]) original, (Object[]) result)) {
+      if (!Objects.deepEquals(original, result)) {
         throw new IllegalStateException("Original and uncompressed " + typeName + " data are different");
       }
     } catch (Exception e) {

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -32,7 +32,7 @@ public class BitShuffleFuzzer {
     fuzz_bitshuffle_shorts(data.consumeShorts(SIZE));
   }
 
-  static void fuzz_bitshuffle_ints(int[] original){
+  static void fuzzBitshuffleInts(int[] original){
     int[] result;
 
     try{   

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -62,7 +62,7 @@ public class BitShuffleFuzzer {
       result = BitShuffle.unshuffleLongArray(uncompressed);
     }
     catch( IOException e ){
-      return;
+      throw new RuntimeException(e);
     }
     
     if(Arrays.equals(original,result) == false)

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -20,62 +20,43 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.BitShuffle;
 import java.util.Arrays;
+import java.util.function.Function;
 
 public class BitShuffleFuzzer {
   private static final int SIZE = 4096;
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    fuzzBitshuffleInts(data.consumeInts(SIZE));
-    fuzzBitshuffleLongs(data.consumeLongs(SIZE));
-    fuzzBitshuffleShorts(data.consumeShorts(SIZE));
-  }
-
-  private static void runFuzz(RunnableWithException block) {
-    try {
-      block.run();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
+    fuzzBitshuffle(data.consumeLongs(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "long[]");
+    fuzzBitshuffle(data.consumeShorts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "short[]");
   }
 
   @FunctionalInterface
-  private interface RunnableWithException {
+  private interface ExceptionRunnable {
     void run() throws Exception;
   }
 
-  private static void fuzzBitshuffleInts(int[] original) {
-    runFuzz(() -> {
-      byte[] shuffledByteArray = BitShuffle.shuffle(original);
-      byte[] compressed = Snappy.compress(shuffledByteArray);
-      byte[] uncompressed = Snappy.uncompress(compressed);
-      int[] result = BitShuffle.unshuffleIntArray(uncompressed);
-      if (!Arrays.equals(original, result)) {
-        throw new IllegalStateException("Original and uncompressed data are different");
-      }
-    });
+  @FunctionalInterface
+  private interface ShuffleFn<T> {
+    byte[] apply(T input) throws Exception;
   }
 
-  private static void fuzzBitshuffleLongs(long[] original) {
-    runFuzz(() -> {
-      byte[] shuffledByteArray = BitShuffle.shuffle(original);
-      byte[] compressed = Snappy.compress(shuffledByteArray);
-      byte[] uncompressed = Snappy.uncompress(compressed);
-      long[] result = BitShuffle.unshuffleLongArray(uncompressed);
-      if (!Arrays.equals(original, result)) {
-        throw new IllegalStateException("Original and uncompressed data are different");
-      }
-    });
+  @FunctionalInterface
+  private interface UnshuffleFn<T> {
+    T apply(byte[] input) throws Exception;
   }
 
-  private static void fuzzBitshuffleShorts(short[] original) {
-    runFuzz(() -> {
-      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+  private static <T> void fuzzBitshuffle(T original, ShuffleFn<T> shuffle, UnshuffleFn<T> unshuffle, String typeName) {
+    try {
+      byte[] shuffledByteArray = shuffle.apply(original);
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
-      short[] result = BitShuffle.unshuffleShortArray(uncompressed);
-      if (!Arrays.equals(original, result)) {
-        throw new IllegalStateException("Original and uncompressed data are different");
+      T result = unshuffle.apply(uncompressed);
+      if (!Arrays.equals((Object[]) original, (Object[]) result)) {
+        throw new IllegalStateException("Original and uncompressed " + typeName + " data are different");
       }
-    });
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -25,11 +25,23 @@ public class BitShuffleFuzzer {
   private static final int SIZE = 4096;
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
-    fuzzBitshuffle(data.consumeLongs(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "long[]");
-    fuzzBitshuffle(data.consumeShorts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "short[]");
-    fuzzBitshuffle(data.consumeFloats(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleFloatArray, "float[]");
-    fuzzBitshuffle(data.consumeDoubles(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleDoubleArray, "double[]");
+    switch (data.consumeInt(0, 4)) {
+      case 0:
+        fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
+        break;
+      case 1:
+        fuzzBitshuffle(data.consumeLongs(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "long[]");
+        break;
+      case 2:
+        fuzzBitshuffle(data.consumeShorts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "short[]");
+        break;
+      case 3:
+        fuzzBitshuffle(data.consumeFloats(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleFloatArray, "float[]");
+        break;
+      case 4:
+        fuzzBitshuffle(data.consumeDoubles(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleDoubleArray, "double[]");
+        break;
+    }
   }
 
   @FunctionalInterface

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -17,6 +17,7 @@
 package org.xerial.snappy.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.BitShuffle;
 import java.util.Objects;
@@ -24,8 +25,9 @@ import java.util.Objects;
 public class BitShuffleFuzzer {
   private static final int SIZE = 4096;
 
+  @FuzzTest
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    switch (data.consumeInt(0, 4)) {
+    switch (data.consumeInt(0, 8)) {
       case 0:
         fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
         break;
@@ -40,6 +42,18 @@ public class BitShuffleFuzzer {
         break;
       case 4:
         fuzzBitshuffle(data.consumeDoubles(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleDoubleArray, "double[]");
+        break;
+      case 5:
+        fuzzBitshuffle(new int[0], BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "empty int[]");
+        break;
+      case 6:
+        fuzzBitshuffle(new float[0], BitShuffle::shuffle, BitShuffle::unshuffleFloatArray, "empty float[]");
+        break;
+      case 7:
+        fuzzBitshuffle(new double[0], BitShuffle::shuffle, BitShuffle::unshuffleDoubleArray, "empty double[]");
+        break;
+      case 8:
+        fuzzBitshuffle(new short[0], BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "empty short[]");
         break;
     }
   }

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -1,0 +1,96 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.xerial.snappy.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.xerial.snappy.Snappy;
+import org.xerial.snappy.BitShuffle;
+import java.io.IOException;
+import java.util.Arrays;
+
+
+public class BitShuffleFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    int SIZE = 4096;
+    fuzz_bitshuffle_ints(data.consumeInts(SIZE));
+    fuzz_bitshuffle_longs(data.consumeLongs(SIZE));
+    fuzz_bitshuffle_shorts(data.consumeShorts(SIZE));
+  }
+
+  static void fuzz_bitshuffle_ints(int[] original){
+    int[] result;
+
+    try{   
+      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+      byte[] compressed = Snappy.compress(shuffledByteArray);
+      byte[] uncompressed = Snappy.uncompress(compressed);
+      result = BitShuffle.unshuffleIntArray(uncompressed);
+    }
+    catch( IOException e ){
+      return;
+    }
+    
+    if(Arrays.equals(original,result) == false)
+    {
+      throw new IllegalStateException("Original and uncompressed data are different");
+    }
+
+  }//fuzz_bitshuffle_ints
+
+  static void fuzz_bitshuffle_longs(long[] original){
+    long[] result;
+
+    try{   
+      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+      byte[] compressed = Snappy.compress(shuffledByteArray);
+      byte[] uncompressed = Snappy.uncompress(compressed);
+      result = BitShuffle.unshuffleLongArray(uncompressed);
+    }
+    catch( IOException e ){
+      return;
+    }
+    
+    if(Arrays.equals(original,result) == false)
+    {
+      throw new IllegalStateException("Original and uncompressed data are different");
+    }
+
+  }//fuzz_bitshuffle_longs
+
+  static void fuzz_bitshuffle_shorts(short[] original){
+    short[] result;
+
+    try{   
+      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+      byte[] compressed = Snappy.compress(shuffledByteArray);
+      byte[] uncompressed = Snappy.uncompress(compressed);
+      result = BitShuffle.unshuffleShortArray(uncompressed);
+    }
+    catch( IOException e ){
+      return;
+    }
+    
+    if(Arrays.equals(original,result) == false)
+    {
+      throw new IllegalStateException("Original and uncompressed data are different");
+    }
+
+  }//fuzz_bitshuffle_shorts  
+
+}
+

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -28,6 +28,8 @@ public class BitShuffleFuzzer {
     fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
     fuzzBitshuffle(data.consumeLongs(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "long[]");
     fuzzBitshuffle(data.consumeShorts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "short[]");
+    fuzzBitshuffle(data.consumeFloats(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleFloatArray, "float[]");
+    fuzzBitshuffle(data.consumeDoubles(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleDoubleArray, "double[]");
   }
 
   @FunctionalInterface

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -27,7 +27,7 @@ public class BitShuffleFuzzer {
 
   @FuzzTest
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    switch (data.consumeInt(0, 8)) {
+    switch (data.consumeInt(0, 9)) {
       case 0:
         fuzzBitshuffle(data.consumeInts(SIZE), BitShuffle::shuffle, BitShuffle::unshuffleIntArray, "int[]");
         break;
@@ -54,6 +54,9 @@ public class BitShuffleFuzzer {
         break;
       case 8:
         fuzzBitshuffle(new short[0], BitShuffle::shuffle, BitShuffle::unshuffleShortArray, "empty short[]");
+        break;
+      case 9:
+        fuzzBitshuffle(new long[0], BitShuffle::shuffle, BitShuffle::unshuffleLongArray, "empty long[]");
         break;
     }
   }

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -82,7 +82,7 @@ public class BitShuffleFuzzer {
       result = BitShuffle.unshuffleShortArray(uncompressed);
     }
     catch( IOException e ){
-      return;
+      throw new RuntimeException(e);
     }
     
     if(Arrays.equals(original,result) == false)

--- a/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
@@ -19,7 +19,6 @@ package org.xerial.snappy.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.BitShuffle;
-import java.io.IOException;
 import java.util.Arrays;
 
 public class BitShuffleFuzzer {
@@ -31,54 +30,52 @@ public class BitShuffleFuzzer {
     fuzzBitshuffleShorts(data.consumeShorts(SIZE));
   }
 
-  static void fuzzBitshuffleInts(int[] original) {
-    int[] result;
-
+  private static void runFuzz(RunnableWithException block) {
     try {
-      byte[] shuffledByteArray = BitShuffle.shuffle(original);
-      byte[] compressed = Snappy.compress(shuffledByteArray);
-      byte[] uncompressed = Snappy.uncompress(compressed);
-      result = BitShuffle.unshuffleIntArray(uncompressed);
-    } catch (IOException e) {
+      block.run();
+    } catch (Exception e) {
       throw new RuntimeException(e);
-    }
-
-    if (!Arrays.equals(original, result)) {
-      throw new IllegalStateException("Original and uncompressed data are different");
     }
   }
 
-  static void fuzzBitshuffleLongs(long[] original) {
-    long[] result;
-
-    try {
-      byte[] shuffledByteArray = BitShuffle.shuffle(original);
-      byte[] compressed = Snappy.compress(shuffledByteArray);
-      byte[] uncompressed = Snappy.uncompress(compressed);
-      result = BitShuffle.unshuffleLongArray(uncompressed);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-
-    if (!Arrays.equals(original, result)) {
-      throw new IllegalStateException("Original and uncompressed data are different");
-    }
+  @FunctionalInterface
+  private interface RunnableWithException {
+    void run() throws Exception;
   }
 
-  static void fuzzBitshuffleShorts(short[] original) {
-    short[] result;
-
-    try {
+  private static void fuzzBitshuffleInts(int[] original) {
+    runFuzz(() -> {
       byte[] shuffledByteArray = BitShuffle.shuffle(original);
       byte[] compressed = Snappy.compress(shuffledByteArray);
       byte[] uncompressed = Snappy.uncompress(compressed);
-      result = BitShuffle.unshuffleShortArray(uncompressed);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+      int[] result = BitShuffle.unshuffleIntArray(uncompressed);
+      if (!Arrays.equals(original, result)) {
+        throw new IllegalStateException("Original and uncompressed data are different");
+      }
+    });
+  }
 
-    if (!Arrays.equals(original, result)) {
-      throw new IllegalStateException("Original and uncompressed data are different");
-    }
+  private static void fuzzBitshuffleLongs(long[] original) {
+    runFuzz(() -> {
+      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+      byte[] compressed = Snappy.compress(shuffledByteArray);
+      byte[] uncompressed = Snappy.uncompress(compressed);
+      long[] result = BitShuffle.unshuffleLongArray(uncompressed);
+      if (!Arrays.equals(original, result)) {
+        throw new IllegalStateException("Original and uncompressed data are different");
+      }
+    });
+  }
+
+  private static void fuzzBitshuffleShorts(short[] original) {
+    runFuzz(() -> {
+      byte[] shuffledByteArray = BitShuffle.shuffle(original);
+      byte[] compressed = Snappy.compress(shuffledByteArray);
+      byte[] uncompressed = Snappy.uncompress(compressed);
+      short[] result = BitShuffle.unshuffleShortArray(uncompressed);
+      if (!Arrays.equals(original, result)) {
+        throw new IllegalStateException("Original and uncompressed data are different");
+      }
+    });
   }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/FuzzBlock.java
+++ b/src/test/java/org/xerial/snappy/fuzz/FuzzBlock.java
@@ -1,0 +1,22 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.xerial.snappy.fuzz;
+
+@FunctionalInterface
+public interface FuzzBlock {
+    void run() throws Exception;
+}

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -263,7 +263,7 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testCrc32C(FuzzedDataProvider data) {
-        switch (data.consumeInt(0, 3)) {
+        switch (data.consumeInt(0, 2)) {
             case 0:
                 runFuzz(() -> {
                     byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
@@ -301,28 +301,6 @@ public class SnappyCombinedFuzzer {
                     crcWhole.update(input, 0, input.length);
                     if (crcChunked.getValue() != crcWhole.getValue()) {
                         throw new IllegalStateException("CRC32C chunked vs whole mismatch");
-                    }
-                });
-                break;
-            case 3:
-                runFuzz(() -> {
-                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-                    PureJavaCrc32C crc = new PureJavaCrc32C();
-                    crc.update(input, 0, input.length);
-                    long value = crc.getValue();
-                    byte[] serialized = new byte[12];
-                    serialized[0] = (byte) (value >>> 56);
-                    serialized[1] = (byte) (value >>> 48);
-                    serialized[2] = (byte) (value >>> 40);
-                    serialized[3] = (byte) (value >>> 32);
-                    serialized[4] = (byte) (value >>> 24);
-                    serialized[5] = (byte) (value >>> 16);
-                    serialized[6] = (byte) (value >>> 8);
-                    serialized[7] = (byte) value;
-                    crc.reset();
-                    crc.update(serialized, 0, 8);
-                    if (crc.getValue() != value) {
-                        throw new IllegalStateException("CRC32C serialization roundtrip failed");
                     }
                 });
                 break;
@@ -496,7 +474,7 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testByteBuffer(FuzzedDataProvider data) {
-        switch (data.consumeInt(0, 3)) {
+        switch (data.consumeInt(0, 1)) {
             case 0:
                 runFuzz(() -> {
                     byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
@@ -524,28 +502,6 @@ public class SnappyCombinedFuzzer {
             case 1:
                 runFuzz(() -> {
                     byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-                    ByteBuffer src = ByteBuffer.wrap(input);
-                    ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
-                    int compressed = Snappy.compress(src, dst);
-                    
-                    dst.limit(compressed);
-                    dst.position(0);
-                    ByteBuffer uncompressedBuf = ByteBuffer.allocate(input.length);
-                    int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
-                    
-                    uncompressedBuf.limit(uncompressed);
-                    uncompressedBuf.position(0);
-                    byte[] result = new byte[uncompressed];
-                    uncompressedBuf.get(result);
-                    
-                    if (!Arrays.equals(input, result)) {
-                        throw new IllegalStateException("Heap ByteBuffer compress failed");
-                    }
-                });
-                break;
-            case 2:
-                runFuzz(() -> {
-                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
                     ByteBuffer src = ByteBuffer.allocateDirect(input.length);
                     src.put(input);
                     src.flip();
@@ -554,20 +510,6 @@ public class SnappyCombinedFuzzer {
                         Snappy.compress(src, dst);
                     } catch (Exception e) {
                         // Expected for invalid input during fuzzing
-                    }
-                });
-                break;
-            case 3:
-                runFuzz(() -> {
-                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-                    if (input.length > 0) {
-                        ByteBuffer src = ByteBuffer.wrap(input);
-                        ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
-                        try {
-                            Snappy.compress(src, dst);
-                        } catch (Exception e) {
-                            // Expected for invalid input during fuzzing
-                        }
                     }
                 });
                 break;

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -1,0 +1,343 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.xerial.snappy.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import org.xerial.snappy.Snappy;
+import org.xerial.snappy.SnappyFramedInputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+import org.xerial.snappy.SnappyInputStream;
+import org.xerial.snappy.SnappyOutputStream;
+import org.xerial.snappy.SnappyHadoopCompatibleOutputStream;
+import org.xerial.snappy.BitShuffle;
+import org.xerial.snappy.PureJavaCrc32C;
+import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class SnappyCombinedFuzzer {
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        int selector = data.consumeInt(0, 7);
+        switch (selector) {
+            case 0:
+                testRawApi(data);
+                break;
+            case 1:
+                testFramed(data);
+                break;
+            case 2:
+                testCrc32C(data);
+                break;
+            case 3:
+                testBlockStream(data);
+                break;
+            case 4:
+                testUtil(data);
+                break;
+            case 5:
+                testBitShuffle(data);
+                break;
+            case 6:
+                testHadoopStream(data);
+                break;
+            case 7:
+                testByteBuffer(data);
+                break;
+        }
+    }
+
+    private static void testRawApi(FuzzedDataProvider data) {
+        byte[] input = data.consumeRemainingAsBytes();
+        
+        try {
+            byte[] compressed = Snappy.compress(input);
+            byte[] uncompressed = Snappy.uncompress(compressed);
+            if (!Arrays.equals(input, uncompressed)) {
+                throw new IllegalStateException("Raw compress/uncompress failed");
+            }
+        } catch (Exception e) {
+        }
+        
+        try {
+            byte[] rawCompressed = Snappy.rawCompress(input, input.length);
+            int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
+            byte[] rawUncompressed = new byte[uncompressedLen];
+            Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
+        } catch (Exception e) {
+        }
+        
+        try {
+            Snappy.isValidCompressedBuffer(input);
+            Snappy.isValidCompressedBuffer(input, 0, input.length);
+        } catch (Exception e) {
+        }
+        
+        try {
+            int maxLen = Snappy.maxCompressedLength(input.length);
+            if (maxLen < input.length) {
+                throw new IllegalStateException("maxCompressedLength too small");
+            }
+        } catch (Exception e) {
+        }
+        
+        try {
+            byte[] compressed = Snappy.compress(input);
+            int len = Snappy.uncompressedLength(compressed);
+            int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
+        } catch (Exception e) {
+        }
+        
+        try {
+            int[] intInput = data.consumeInts(100);
+            byte[] compressedInts = Snappy.compress(intInput);
+            int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
+        } catch (Exception e) {
+        }
+        
+        try {
+            long[] longInput = data.consumeLongs(50);
+            byte[] compressedLongs = Snappy.compress(longInput);
+            long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
+        } catch (Exception e) {
+        }
+    }
+
+    private static void testFramed(FuzzedDataProvider data) {
+        byte[] original = data.consumeRemainingAsBytes();
+        
+        try {
+            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+            SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
+            framedOut.write(original);
+            framedOut.close();
+            byte[] compressed = compressedBuf.toByteArray();
+            
+            for (int bufferSize : new int[]{1, 64, 256, 1024, 4096}) {
+                SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
+                    new ByteArrayInputStream(compressed), true);
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buf = new byte[bufferSize];
+                int readBytes;
+                while ((readBytes = framedIn.read(buf)) != -1) {
+                    out.write(buf, 0, readBytes);
+                }
+                out.flush();
+            }
+        } catch (IOException e) {
+        }
+        
+        try {
+            byte[] invalidData = data.consumeBytes(100);
+            SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
+                new ByteArrayInputStream(invalidData));
+            while (invalidIn.read() != -1) {}
+        } catch (IOException e) {
+        }
+    }
+
+    private static void testCrc32C(FuzzedDataProvider data) {
+        byte[] input = data.consumeRemainingAsBytes();
+        PureJavaCrc32C crc = new PureJavaCrc32C();
+        
+        crc.update(input, 0, input.length);
+        long value = crc.getValue();
+        
+        int intValue = crc.getIntegerValue();
+        
+        crc.reset();
+        crc.update(input, 0, input.length);
+        long value2 = crc.getValue();
+        
+        PureJavaCrc32C crcChunked = new PureJavaCrc32C();
+        for (int i = 0; i < Math.min(input.length, 1000); i++) {
+            crcChunked.update(input[i] & 0xFF);
+        }
+        
+        if (input.length > 2) {
+            byte[] partial1 = data.consumeBytes(Math.min(10, input.length));
+            byte[] partial2 = data.consumeBytes(Math.min(10, input.length));
+            
+            PureJavaCrc32C crc1 = new PureJavaCrc32C();
+            crc1.update(input, 0, input.length);
+            
+            PureJavaCrc32C crc2 = new PureJavaCrc32C();
+            crc2.update(partial1, 0, partial1.length);
+            crc2.update(partial2, 0, partial2.length);
+        }
+        
+        PureJavaCrc32C crcEmpty = new PureJavaCrc32C();
+        crcEmpty.update(new byte[0], 0, 0);
+        long emptyValue = crcEmpty.getValue();
+        
+        if (input.length > 0) {
+            PureJavaCrc32C crcSingle = new PureJavaCrc32C();
+            crcSingle.update(input[0] & 0xFF);
+        }
+        
+        if (input.length > 4) {
+            PureJavaCrc32C crcOffset = new PureJavaCrc32C();
+            crcOffset.update(input, 1, input.length - 1);
+        }
+    }
+
+    private static void testBlockStream(FuzzedDataProvider data) {
+        byte[] original = data.consumeRemainingAsBytes();
+        
+        try {
+            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+            SnappyOutputStream out = new SnappyOutputStream(compressedBuf, -1);
+            out.write(original);
+            out.close();
+            byte[] compressed = compressedBuf.toByteArray();
+            
+            SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed));
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            byte[] buf = new byte[1024];
+            int read;
+            while ((read = in.read(buf)) != -1) {
+                result.write(buf, 0, read);
+            }
+            in.close();
+        } catch (Exception e) {
+        }
+        
+        try {
+            byte[] invalid = data.consumeBytes(100);
+            SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(invalid));
+            while (in.read() != -1) {}
+        } catch (Exception e) {
+        }
+    }
+
+    private static void testUtil(FuzzedDataProvider data) {
+        byte[] input = data.consumeRemainingAsBytes();
+        
+        try {
+            String str = new String(input, java.nio.charset.StandardCharsets.UTF_8);
+            byte[] compressed = Snappy.compress(str);
+            String uncompressed = Snappy.uncompressString(compressed);
+        } catch (Exception e) {
+        }
+        
+        try {
+            int maxLen = Snappy.maxCompressedLength(input.length);
+        } catch (Exception e) {
+        }
+        
+        try {
+            short[] shortInput = new short[Math.min(100, input.length / 2)];
+            for (int i = 0; i < shortInput.length; i++) {
+                shortInput[i] = (short) data.consumeInt();
+            }
+            byte[] compressedShorts = Snappy.compress(shortInput);
+            short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
+        } catch (Exception e) {
+        }
+        
+        try {
+            char[] charInput = new char[Math.min(100, input.length)];
+            for (int i = 0; i < charInput.length; i++) {
+                charInput[i] = (char) data.consumeInt();
+            }
+            byte[] compressedChars = Snappy.compress(charInput);
+            char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
+        } catch (Exception e) {
+        }
+    }
+
+    private static void testBitShuffle(FuzzedDataProvider data) {
+        try {
+            int[] intInput = data.consumeInts(100);
+            byte[] shuffled = BitShuffle.shuffle(intInput);
+            int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
+        } catch (Exception e) {
+        }
+        
+        try {
+            long[] longInput = data.consumeLongs(50);
+            byte[] shuffled = BitShuffle.shuffle(longInput);
+            long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
+        } catch (Exception e) {
+        }
+        
+        try {
+            short[] shortInput = data.consumeShorts(100);
+            byte[] shuffled = BitShuffle.shuffle(shortInput);
+            short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
+        } catch (Exception e) {
+        }
+    }
+
+    private static void testHadoopStream(FuzzedDataProvider data) {
+        byte[] original = data.consumeRemainingAsBytes();
+        
+        try {
+            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+            SnappyHadoopCompatibleOutputStream out = new SnappyHadoopCompatibleOutputStream(compressedBuf);
+            out.write(original);
+            out.close();
+            byte[] compressed = compressedBuf.toByteArray();
+            
+            SnappyInputStream in = new SnappyInputStream(
+                new ByteArrayInputStream(compressed));
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            byte[] buf = new byte[1024];
+            int read;
+            while ((read = in.read(buf)) != -1) {
+                result.write(buf, 0, read);
+            }
+            in.close();
+        } catch (Exception e) {
+        }
+    }
+
+    private static void testByteBuffer(FuzzedDataProvider data) {
+        byte[] input = data.consumeRemainingAsBytes();
+        
+        try {
+            ByteBuffer src = ByteBuffer.wrap(input);
+            ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
+            int compressed = Snappy.compress(src, dst);
+            
+            dst.limit(compressed);
+            dst.position(0);
+            ByteBuffer uncompressedBuf = ByteBuffer.allocate(input.length);
+            int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
+            
+            uncompressedBuf.limit(uncompressed);
+            byte[] result = new byte[uncompressed];
+            uncompressedBuf.get(result);
+            
+            if (!Arrays.equals(input, result)) {
+                throw new IllegalStateException("ByteBuffer compress failed");
+            }
+        } catch (Exception e) {
+        }
+        
+        try {
+            ByteBuffer directSrc = ByteBuffer.allocateDirect(input.length);
+            directSrc.put(input);
+            directSrc.flip();
+            
+            ByteBuffer directDst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
+            Snappy.compress(directSrc, directDst);
+        } catch (Exception e) {
+        }
+    }
+}

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -17,6 +17,7 @@
 package org.xerial.snappy.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
 import org.xerial.snappy.Snappy;
 import org.xerial.snappy.SnappyFramedInputStream;
 import org.xerial.snappy.SnappyFramedOutputStream;
@@ -41,6 +42,7 @@ public class SnappyCombinedFuzzer {
         }
     }
     
+    @FuzzTest
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int selector = data.consumeInt(0, 7);
         switch (selector) {
@@ -51,7 +53,7 @@ public class SnappyCombinedFuzzer {
                 testFramed(data);
                 break;
             case 2:
-                testCrc32C(data);
+                runFuzz(() -> testCrc32C(data));
                 break;
             case 3:
                 testBlockStream(data);
@@ -72,7 +74,7 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testRawApi(FuzzedDataProvider data) {
-        switch (data.consumeInt(0, 6)) {
+        switch (data.consumeInt(0, 10)) {
             case 0:
                 runFuzz(() -> {
                     byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
@@ -106,6 +108,7 @@ public class SnappyCombinedFuzzer {
                         Snappy.isValidCompressedBuffer(input);
                         Snappy.isValidCompressedBuffer(input, 0, input.length);
                     } catch (IOException e) {
+                        // Expected for invalid compressed buffers during fuzzing
                     }
                 });
                 break;
@@ -151,217 +154,423 @@ public class SnappyCombinedFuzzer {
                     }
                 });
                 break;
+            case 7:
+                runFuzz(() -> {
+                    byte[] input = new byte[0];
+                    byte[] compressed = Snappy.compress(input);
+                    byte[] uncompressed = Snappy.uncompress(compressed);
+                    if (!Arrays.equals(input, uncompressed)) {
+                        throw new IllegalStateException("Empty array roundtrip failed");
+                    }
+                });
+                break;
+            case 8:
+                runFuzz(() -> {
+                    byte[] input = new byte[]{data.consumeByte()};
+                    byte[] compressed = Snappy.compress(input);
+                    byte[] uncompressed = Snappy.uncompress(compressed);
+                    if (!Arrays.equals(input, uncompressed)) {
+                        throw new IllegalStateException("Single byte roundtrip failed");
+                    }
+                });
+                break;
+            case 9:
+                runFuzz(() -> {
+                    int size = data.consumeInt(4095, 4096);
+                    byte[] input = data.consumeBytes(size);
+                    byte[] compressed = Snappy.compress(input);
+                    byte[] uncompressed = Snappy.uncompress(compressed);
+                    if (!Arrays.equals(input, uncompressed)) {
+                        throw new IllegalStateException("Max size roundtrip failed");
+                    }
+                });
+                break;
+            case 10:
+                runFuzz(() -> {
+                    try {
+                        int len = data.consumeInt(Integer.MAX_VALUE - 1000, Integer.MAX_VALUE);
+                        Snappy.maxCompressedLength(len);
+                    } catch (Exception e) {
+                        // Expected for overflow/illegal argument
+                    }
+                });
+                break;
         }
     }
 
     private static void testFramed(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
-            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
-            SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
-            framedOut.write(original);
-            framedOut.close();
-            byte[] compressed = compressedBuf.toByteArray();
+        switch (data.consumeInt(0, 2)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+                    SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
+                    framedOut.write(original);
+                    framedOut.close();
+                    byte[] compressed = compressedBuf.toByteArray();
 
-            for (int bufferSize : new int[]{1, 64, 256, 1024, 4096}) {
-                try (SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
-                    new ByteArrayInputStream(compressed), true)) {
-                    ByteArrayOutputStream out = new ByteArrayOutputStream();
-                    byte[] buf = new byte[bufferSize];
-                    int readBytes;
-                    while ((readBytes = framedIn.read(buf)) != -1) {
-                        out.write(buf, 0, readBytes);
+                    int bufferSize = data.consumeInt(1, 4096);
+                    try (SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
+                        new ByteArrayInputStream(compressed), true)) {
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        byte[] buf = new byte[bufferSize];
+                        int readBytes;
+                        while ((readBytes = framedIn.read(buf)) != -1) {
+                            out.write(buf, 0, readBytes);
+                        }
+                        if (!Arrays.equals(original, out.toByteArray())) {
+                            throw new IllegalStateException("Framed stream roundtrip failed");
+                        }
                     }
-                    if (!Arrays.equals(original, out.toByteArray())) {
-                        throw new IllegalStateException("Framed stream roundtrip failed");
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
+                        new ByteArrayInputStream(data.consumeBytes(100)))) {
+                        while (invalidIn.read() != -1) {}
+                    } catch (IOException e) {
+                        // Expected for malformed input during fuzzing
                     }
-                }
-            }
-        });
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+                    SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
+                    framedOut.write(original);
+                    framedOut.close();
+                    byte[] compressed = compressedBuf.toByteArray();
 
-        runFuzz(() -> {
-            try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
-                new ByteArrayInputStream(data.consumeBytes(100)))) {
-                while (invalidIn.read() != -1) {}
-            } catch (IOException e) {
-            }
-        });
+                    for (int bufferSize : new int[]{1, 64, 256, 1024, 4096}) {
+                        try (SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
+                            new ByteArrayInputStream(compressed), true)) {
+                            ByteArrayOutputStream out = new ByteArrayOutputStream();
+                            byte[] buf = new byte[bufferSize];
+                            int readBytes;
+                            while ((readBytes = framedIn.read(buf)) != -1) {
+                                out.write(buf, 0, readBytes);
+                            }
+                            if (!Arrays.equals(original, out.toByteArray())) {
+                                throw new IllegalStateException("Framed stream roundtrip failed");
+                            }
+                        }
+                    }
+                });
+                break;
+        }
     }
 
     private static void testCrc32C(FuzzedDataProvider data) {
-        byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-        
-        PureJavaCrc32C crc = new PureJavaCrc32C();
-        crc.update(input, 0, input.length);
-        long value = crc.getValue();
-        
-        int intValue = crc.getIntegerValue();
-        if ((int) value != intValue) {
-            throw new IllegalStateException("CRC32C int value mismatch");
-        }
-        
-        crc.reset();
-        crc.update(input, 0, input.length);
-        long value2 = crc.getValue();
-        if (value != value2) {
-            throw new IllegalStateException("CRC32C reset produced different value");
-        }
-        
-        PureJavaCrc32C crcChunked = new PureJavaCrc32C();
-        for (int i = 0; i < input.length; i++) {
-            crcChunked.update(input[i] & 0xFF);
-        }
-        
-        PureJavaCrc32C crcWhole = new PureJavaCrc32C();
-        crcWhole.update(input, 0, input.length);
-        
-        if (crcChunked.getValue() != crcWhole.getValue()) {
-            throw new IllegalStateException("CRC32C chunked vs whole mismatch");
+        switch (data.consumeInt(0, 3)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    PureJavaCrc32C crc = new PureJavaCrc32C();
+                    crc.update(input, 0, input.length);
+                    long value = crc.getValue();
+                    int intValue = crc.getIntegerValue();
+                    if ((int) value != intValue) {
+                        throw new IllegalStateException("CRC32C int value mismatch");
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    PureJavaCrc32C crc = new PureJavaCrc32C();
+                    crc.update(input, 0, input.length);
+                    long value = crc.getValue();
+                    crc.reset();
+                    crc.update(input, 0, input.length);
+                    long value2 = crc.getValue();
+                    if (value != value2) {
+                        throw new IllegalStateException("CRC32C reset produced different value");
+                    }
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    PureJavaCrc32C crcChunked = new PureJavaCrc32C();
+                    for (int i = 0; i < input.length; i++) {
+                        crcChunked.update(input[i] & 0xFF);
+                    }
+                    PureJavaCrc32C crcWhole = new PureJavaCrc32C();
+                    crcWhole.update(input, 0, input.length);
+                    if (crcChunked.getValue() != crcWhole.getValue()) {
+                        throw new IllegalStateException("CRC32C chunked vs whole mismatch");
+                    }
+                });
+                break;
+            case 3:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    PureJavaCrc32C crc = new PureJavaCrc32C();
+                    crc.update(input, 0, input.length);
+                    long value = crc.getValue();
+                    byte[] serialized = new byte[12];
+                    serialized[0] = (byte) (value >>> 56);
+                    serialized[1] = (byte) (value >>> 48);
+                    serialized[2] = (byte) (value >>> 40);
+                    serialized[3] = (byte) (value >>> 32);
+                    serialized[4] = (byte) (value >>> 24);
+                    serialized[5] = (byte) (value >>> 16);
+                    serialized[6] = (byte) (value >>> 8);
+                    serialized[7] = (byte) value;
+                    crc.reset();
+                    crc.update(serialized, 0, 8);
+                    if (crc.getValue() != value) {
+                        throw new IllegalStateException("CRC32C serialization roundtrip failed");
+                    }
+                });
+                break;
         }
     }
 
     private static void testBlockStream(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
-            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
-            SnappyOutputStream out = new SnappyOutputStream(compressedBuf, SnappyOutputStream.MIN_BLOCK_SIZE);
-            out.write(original);
-            out.close();
-            byte[] compressed = compressedBuf.toByteArray();
+        switch (data.consumeInt(0, 1)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+                    SnappyOutputStream out = new SnappyOutputStream(compressedBuf, SnappyOutputStream.MIN_BLOCK_SIZE);
+                    out.write(original);
+                    out.close();
+                    byte[] compressed = compressedBuf.toByteArray();
 
-            try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
-                ByteArrayOutputStream result = new ByteArrayOutputStream();
-                byte[] buf = new byte[1024];
-                int read;
-                while ((read = in.read(buf)) != -1) {
-                    result.write(buf, 0, read);
-                }
-                if (!Arrays.equals(original, result.toByteArray())) {
-                    throw new IllegalStateException("Block stream roundtrip failed");
-                }
-            }
-        });
-
-        runFuzz(() -> {
-            try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
-                while (in.read() != -1) {}
-            } catch (IOException e) {
-            }
-        });
+                    int bufferSize = data.consumeInt(1, 4096);
+                    try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+                        ByteArrayOutputStream result = new ByteArrayOutputStream();
+                        byte[] buf = new byte[bufferSize];
+                        int read;
+                        while ((read = in.read(buf)) != -1) {
+                            result.write(buf, 0, read);
+                        }
+                        if (!Arrays.equals(original, result.toByteArray())) {
+                            throw new IllegalStateException("Block stream roundtrip failed");
+                        }
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
+                        while (in.read() != -1) {}
+                    } catch (IOException e) {
+                        // Expected for malformed input during fuzzing
+                    }
+                });
+                break;
+        }
     }
 
     private static void testUtil(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            String str = data.consumeString(data.consumeInt(0, 4096));
-            byte[] compressed = Snappy.compress(str);
-            String uncompressed = Snappy.uncompressString(compressed);
-            if (!str.equals(uncompressed)) {
-                throw new IllegalStateException("String roundtrip failed");
-            }
-        });
-
-        runFuzz(() -> {
-            int len = data.consumeInt(0, 4096);
-            int maxLen = Snappy.maxCompressedLength(len);
-            if (maxLen < len) {
-                throw new IllegalStateException("maxCompressedLength too small");
-            }
-        });
-
-        runFuzz(() -> {
-            short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
-            byte[] compressedShorts = Snappy.compress(shortInput);
-            short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
-            if (!Arrays.equals(shortInput, uncompressedShorts)) {
-                throw new IllegalStateException("Short array roundtrip failed");
-            }
-        });
-
-        runFuzz(() -> {
-            char[] charInput = data.consumeString(data.consumeInt(0, 100)).toCharArray();
-            byte[] compressedChars = Snappy.compress(charInput);
-            char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
-            if (!Arrays.equals(charInput, uncompressedChars)) {
-                throw new IllegalStateException("Char array roundtrip failed");
-            }
-        });
+        switch (data.consumeInt(0, 4)) {
+            case 0:
+                runFuzz(() -> {
+                    String str = data.consumeString(data.consumeInt(0, 4096));
+                    byte[] compressed = Snappy.compress(str);
+                    String uncompressed = Snappy.uncompressString(compressed);
+                    if (!str.equals(uncompressed)) {
+                        throw new IllegalStateException("String roundtrip failed");
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
+                    byte[] compressedShorts = Snappy.compress(shortInput);
+                    short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
+                    if (!Arrays.equals(shortInput, uncompressedShorts)) {
+                        throw new IllegalStateException("Short array roundtrip failed");
+                    }
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    char[] charInput = data.consumeString(data.consumeInt(0, 100)).toCharArray();
+                    byte[] compressedChars = Snappy.compress(charInput);
+                    char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
+                    if (!Arrays.equals(charInput, uncompressedChars)) {
+                        throw new IllegalStateException("Char array roundtrip failed");
+                    }
+                });
+                break;
+            case 3:
+                runFuzz(() -> {
+                    float[] floatInput = data.consumeFloats(data.consumeInt(0, 100));
+                    byte[] shuffled = BitShuffle.shuffle(floatInput);
+                    float[] unshuffled = BitShuffle.unshuffleFloatArray(shuffled);
+                    if (!Arrays.equals(floatInput, unshuffled)) {
+                        throw new IllegalStateException("BitShuffle float failed");
+                    }
+                });
+                break;
+            case 4:
+                runFuzz(() -> {
+                    double[] doubleInput = data.consumeDoubles(data.consumeInt(0, 50));
+                    byte[] shuffled = BitShuffle.shuffle(doubleInput);
+                    double[] unshuffled = BitShuffle.unshuffleDoubleArray(shuffled);
+                    if (!Arrays.equals(doubleInput, unshuffled)) {
+                        throw new IllegalStateException("BitShuffle double failed");
+                    }
+                });
+                break;
+        }
     }
 
     private static void testBitShuffle(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            int[] intInput = data.consumeInts(data.consumeInt(0, 100));
-            byte[] shuffled = BitShuffle.shuffle(intInput);
-            int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
-            if (!Arrays.equals(intInput, unshuffled)) {
-                throw new IllegalStateException("BitShuffle int failed");
-            }
-        });
-        
-        runFuzz(() -> {
-            long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
-            byte[] shuffled = BitShuffle.shuffle(longInput);
-            long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
-            if (!Arrays.equals(longInput, unshuffled)) {
-                throw new IllegalStateException("BitShuffle long failed");
-            }
-        });
-        
-        runFuzz(() -> {
-            short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
-            byte[] shuffled = BitShuffle.shuffle(shortInput);
-            short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
-            if (!Arrays.equals(shortInput, unshuffled)) {
-                throw new IllegalStateException("BitShuffle short failed");
-            }
-        });
+        switch (data.consumeInt(0, 2)) {
+            case 0:
+                runFuzz(() -> {
+                    int[] intInput = data.consumeInts(data.consumeInt(0, 100));
+                    byte[] shuffled = BitShuffle.shuffle(intInput);
+                    int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
+                    if (!Arrays.equals(intInput, unshuffled)) {
+                        throw new IllegalStateException("BitShuffle int failed");
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
+                    byte[] shuffled = BitShuffle.shuffle(longInput);
+                    long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
+                    if (!Arrays.equals(longInput, unshuffled)) {
+                        throw new IllegalStateException("BitShuffle long failed");
+                    }
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
+                    byte[] shuffled = BitShuffle.shuffle(shortInput);
+                    short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
+                    if (!Arrays.equals(shortInput, unshuffled)) {
+                        throw new IllegalStateException("BitShuffle short failed");
+                    }
+                });
+                break;
+        }
     }
 
     private static void testHadoopStream(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
-            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
-            SnappyHadoopCompatibleOutputStream out = new SnappyHadoopCompatibleOutputStream(compressedBuf);
-            out.write(original);
-            out.close();
-            byte[] compressed = compressedBuf.toByteArray();
+        switch (data.consumeInt(0, 1)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+                    SnappyHadoopCompatibleOutputStream out = new SnappyHadoopCompatibleOutputStream(compressedBuf);
+                    out.write(original);
+                    out.close();
+                    byte[] compressed = compressedBuf.toByteArray();
 
-            try (SnappyInputStream in = new SnappyInputStream(
-                new ByteArrayInputStream(compressed))) {
-                ByteArrayOutputStream result = new ByteArrayOutputStream();
-                byte[] buf = new byte[1024];
-                int read;
-                while ((read = in.read(buf)) != -1) {
-                    result.write(buf, 0, read);
-                }
-                if (!Arrays.equals(original, result.toByteArray())) {
-                    throw new IllegalStateException("Hadoop stream roundtrip failed");
-                }
-            }
-        });
+                    int bufferSize = data.consumeInt(1, 4096);
+                    try (SnappyInputStream in = new SnappyInputStream(
+                        new ByteArrayInputStream(compressed))) {
+                        ByteArrayOutputStream result = new ByteArrayOutputStream();
+                        byte[] buf = new byte[bufferSize];
+                        int read;
+                        while ((read = in.read(buf)) != -1) {
+                            result.write(buf, 0, read);
+                        }
+                        if (!Arrays.equals(original, result.toByteArray())) {
+                            throw new IllegalStateException("Hadoop stream roundtrip failed");
+                        }
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    try (SnappyInputStream in = new SnappyInputStream(
+                        new ByteArrayInputStream(data.consumeBytes(100)))) {
+                        while (in.read() != -1) {}
+                    } catch (IOException e) {
+                        // Expected for malformed input during fuzzing
+                    }
+                });
+                break;
+        }
     }
 
     private static void testByteBuffer(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            ByteBuffer src = ByteBuffer.allocateDirect(input.length);
-            src.put(input);
-            src.flip();
-            ByteBuffer dst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
-            int compressed = Snappy.compress(src, dst);
-            
-            dst.limit(compressed);
-            dst.position(0);
-            ByteBuffer uncompressedBuf = ByteBuffer.allocateDirect(input.length);
-            int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
-            
-            uncompressedBuf.limit(uncompressed);
-            uncompressedBuf.position(0);
-            byte[] result = new byte[uncompressed];
-            uncompressedBuf.get(result);
-            
-            if (!Arrays.equals(input, result)) {
-                throw new IllegalStateException("ByteBuffer compress failed");
-            }
-        });
+        switch (data.consumeInt(0, 3)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteBuffer src = ByteBuffer.allocateDirect(input.length);
+                    src.put(input);
+                    src.flip();
+                    ByteBuffer dst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
+                    int compressed = Snappy.compress(src, dst);
+                    
+                    dst.limit(compressed);
+                    dst.position(0);
+                    ByteBuffer uncompressedBuf = ByteBuffer.allocateDirect(input.length);
+                    int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
+                    
+                    uncompressedBuf.limit(uncompressed);
+                    uncompressedBuf.position(0);
+                    byte[] result = new byte[uncompressed];
+                    uncompressedBuf.get(result);
+                    
+                    if (!Arrays.equals(input, result)) {
+                        throw new IllegalStateException("ByteBuffer compress failed");
+                    }
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteBuffer src = ByteBuffer.wrap(input);
+                    ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
+                    int compressed = Snappy.compress(src, dst);
+                    
+                    dst.limit(compressed);
+                    dst.position(0);
+                    ByteBuffer uncompressedBuf = ByteBuffer.allocate(input.length);
+                    int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
+                    
+                    uncompressedBuf.limit(uncompressed);
+                    uncompressedBuf.position(0);
+                    byte[] result = new byte[uncompressed];
+                    uncompressedBuf.get(result);
+                    
+                    if (!Arrays.equals(input, result)) {
+                        throw new IllegalStateException("Heap ByteBuffer compress failed");
+                    }
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    ByteBuffer src = ByteBuffer.allocateDirect(input.length);
+                    src.put(input);
+                    src.flip();
+                    ByteBuffer dst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
+                    try {
+                        Snappy.compress(src, dst);
+                    } catch (Exception e) {
+                        // Expected for invalid input during fuzzing
+                    }
+                });
+                break;
+            case 3:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    if (input.length > 0) {
+                        ByteBuffer src = ByteBuffer.wrap(input);
+                        ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
+                        try {
+                            Snappy.compress(src, dst);
+                        } catch (Exception e) {
+                            // Expected for invalid input during fuzzing
+                        }
+                    }
+                });
+                break;
+        }
     }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -81,12 +81,14 @@ public class SnappyCombinedFuzzer {
             byte[] rawUncompressed = new byte[uncompressedLen];
             Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
             Snappy.isValidCompressedBuffer(input);
             Snappy.isValidCompressedBuffer(input, 0, input.length);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -95,6 +97,7 @@ public class SnappyCombinedFuzzer {
                 throw new IllegalStateException("maxCompressedLength too small");
             }
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -102,6 +105,7 @@ public class SnappyCombinedFuzzer {
             int len = Snappy.uncompressedLength(compressed);
             int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -109,6 +113,7 @@ public class SnappyCombinedFuzzer {
             byte[] compressedInts = Snappy.compress(intInput);
             int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -116,6 +121,7 @@ public class SnappyCombinedFuzzer {
             byte[] compressedLongs = Snappy.compress(longInput);
             long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -149,7 +155,7 @@ public class SnappyCombinedFuzzer {
             new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (invalidIn.read() != -1) {}
         } catch (IOException e) {
-            // Expected, ignore.
+            throw new RuntimeException(e);
         }
     }
 
@@ -223,7 +229,7 @@ public class SnappyCombinedFuzzer {
         try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (in.read() != -1) {}
         } catch (Exception e) {
-            // Expected, ignore.
+            throw new RuntimeException(e);
         }
     }
 
@@ -235,11 +241,13 @@ public class SnappyCombinedFuzzer {
             byte[] compressed = Snappy.compress(str);
             String uncompressed = Snappy.uncompressString(compressed);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
             int maxLen = Snappy.maxCompressedLength(input.length);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -250,6 +258,7 @@ public class SnappyCombinedFuzzer {
             byte[] compressedShorts = Snappy.compress(shortInput);
             short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -260,6 +269,7 @@ public class SnappyCombinedFuzzer {
             byte[] compressedChars = Snappy.compress(charInput);
             char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -269,6 +279,7 @@ public class SnappyCombinedFuzzer {
             byte[] shuffled = BitShuffle.shuffle(intInput);
             int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -276,6 +287,7 @@ public class SnappyCombinedFuzzer {
             byte[] shuffled = BitShuffle.shuffle(longInput);
             long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -283,6 +295,7 @@ public class SnappyCombinedFuzzer {
             byte[] shuffled = BitShuffle.shuffle(shortInput);
             short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -296,16 +309,17 @@ public class SnappyCombinedFuzzer {
             out.close();
             byte[] compressed = compressedBuf.toByteArray();
             
-            SnappyInputStream in = new SnappyInputStream(
-                new ByteArrayInputStream(compressed));
-            ByteArrayOutputStream result = new ByteArrayOutputStream();
-            byte[] buf = new byte[1024];
-            int read;
-            while ((read = in.read(buf)) != -1) {
-                result.write(buf, 0, read);
+            try (SnappyInputStream in = new SnappyInputStream(
+                new ByteArrayInputStream(compressed))) {
+                ByteArrayOutputStream result = new ByteArrayOutputStream();
+                byte[] buf = new byte[1024];
+                int read;
+                while ((read = in.read(buf)) != -1) {
+                    result.write(buf, 0, read);
+                }
             }
-            in.close();
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -333,6 +347,7 @@ public class SnappyCombinedFuzzer {
                 throw new IllegalStateException("ByteBuffer compress failed");
             }
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {
@@ -343,6 +358,7 @@ public class SnappyCombinedFuzzer {
             ByteBuffer directDst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
             Snappy.compress(directSrc, directDst);
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -209,7 +209,7 @@ public class SnappyCombinedFuzzer {
         runFuzz(() -> {
             byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
-            SnappyOutputStream out = new SnappyOutputStream(compressedBuf, -1);
+            SnappyOutputStream out = new SnappyOutputStream(compressedBuf, SnappyOutputStream.MIN_BLOCK_SIZE);
             out.write(original);
             out.close();
             byte[] compressed = compressedBuf.toByteArray();

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -28,7 +28,6 @@ import org.xerial.snappy.PureJavaCrc32C;
 import java.nio.ByteBuffer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.Arrays;
 
 public class SnappyCombinedFuzzer {

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -72,6 +72,7 @@ public class SnappyCombinedFuzzer {
                 throw new IllegalStateException("Raw compress/uncompress failed");
             }
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
         try {

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -28,6 +28,7 @@ import org.xerial.snappy.PureJavaCrc32C;
 import java.nio.ByteBuffer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 
 public class SnappyCombinedFuzzer {
@@ -96,9 +97,12 @@ public class SnappyCombinedFuzzer {
         });
 
         runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            Snappy.isValidCompressedBuffer(input);
-            Snappy.isValidCompressedBuffer(input, 0, input.length);
+            try {
+                byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                Snappy.isValidCompressedBuffer(input);
+                Snappy.isValidCompressedBuffer(input, 0, input.length);
+            } catch (IOException e) {
+            }
         });
 
         runFuzz(() -> {
@@ -169,6 +173,7 @@ public class SnappyCombinedFuzzer {
             try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
                 new ByteArrayInputStream(data.consumeBytes(100)))) {
                 while (invalidIn.read() != -1) {}
+            } catch (IOException e) {
             }
         });
     }
@@ -230,6 +235,7 @@ public class SnappyCombinedFuzzer {
         runFuzz(() -> {
             try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
                 while (in.read() != -1) {}
+            } catch (IOException e) {
             }
         });
     }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -76,64 +76,84 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testRawApi(FuzzedDataProvider data) {
-        byte[] input = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             byte[] compressed = Snappy.compress(input);
             byte[] uncompressed = Snappy.uncompress(compressed);
             if (!Arrays.equals(input, uncompressed)) {
                 throw new IllegalStateException("Raw compress/uncompress failed");
             }
         });
-        
+
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             byte[] rawCompressed = Snappy.rawCompress(input, input.length);
-            int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
-            byte[] rawUncompressed = new byte[uncompressedLen];
-            Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
+            if (Snappy.isValidCompressedBuffer(rawCompressed)) {
+                int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
+                if (uncompressedLen == input.length) {
+                    byte[] rawUncompressed = new byte[uncompressedLen];
+                    Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
+                    if (!Arrays.equals(input, rawUncompressed)) {
+                        throw new IllegalStateException("Raw compress/uncompress with byte[] failed");
+                    }
+                }
+            }
         });
-        
+
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             Snappy.isValidCompressedBuffer(input);
             Snappy.isValidCompressedBuffer(input, 0, input.length);
         });
-        
+
         runFuzz(() -> {
-            int maxLen = Snappy.maxCompressedLength(input.length);
-            if (maxLen < input.length) {
+            int inputLength = data.consumeInt(0, 4096);
+            int maxLen = Snappy.maxCompressedLength(inputLength);
+            if (maxLen < inputLength) {
                 throw new IllegalStateException("maxCompressedLength too small");
             }
         });
-        
+
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             byte[] compressed = Snappy.compress(input);
-            int len = Snappy.uncompressedLength(compressed);
-            int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
+            if (Snappy.isValidCompressedBuffer(compressed)) {
+                int len = Snappy.uncompressedLength(compressed);
+                int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
+                if (len != input.length || len2 != input.length) {
+                    throw new IllegalStateException("uncompressedLength did not match original length");
+                }
+            }
         });
-        
+
         runFuzz(() -> {
-            int[] intInput = data.consumeInts(100);
+            int[] intInput = data.consumeInts(data.consumeInt(0, 100));
             byte[] compressedInts = Snappy.compress(intInput);
             int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
+            if (!Arrays.equals(intInput, uncompressedInts)) {
+                throw new IllegalStateException("Int array roundtrip failed");
+            }
         });
-        
+
         runFuzz(() -> {
-            long[] longInput = data.consumeLongs(50);
+            long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
             byte[] compressedLongs = Snappy.compress(longInput);
             long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
+            if (!Arrays.equals(longInput, uncompressedLongs)) {
+                throw new IllegalStateException("Long array roundtrip failed");
+            }
         });
     }
 
     private static void testFramed(FuzzedDataProvider data) {
-        byte[] original = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
+            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
             framedOut.write(original);
             framedOut.close();
             byte[] compressed = compressedBuf.toByteArray();
-            
+
             for (int bufferSize : new int[]{1, 64, 256, 1024, 4096}) {
                 try (SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
                     new ByteArrayInputStream(compressed), true)) {
@@ -143,11 +163,13 @@ public class SnappyCombinedFuzzer {
                     while ((readBytes = framedIn.read(buf)) != -1) {
                         out.write(buf, 0, readBytes);
                     }
-                    out.flush();
+                    if (!Arrays.equals(original, out.toByteArray())) {
+                        throw new IllegalStateException("Framed stream roundtrip failed");
+                    }
                 }
             }
         });
-        
+
         runFuzz(() -> {
             try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
                 new ByteArrayInputStream(data.consumeBytes(100)))) {
@@ -157,7 +179,7 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testCrc32C(FuzzedDataProvider data) {
-        byte[] input = data.consumeRemainingAsBytes();
+        byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
         byte[] chunk1 = data.consumeBytes(50);
         byte[] chunk2 = data.consumeBytes(50);
         
@@ -204,15 +226,14 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testBlockStream(FuzzedDataProvider data) {
-        byte[] original = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
+            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyOutputStream out = new SnappyOutputStream(compressedBuf, -1);
             out.write(original);
             out.close();
             byte[] compressed = compressedBuf.toByteArray();
-            
+
             try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
                 ByteArrayOutputStream result = new ByteArrayOutputStream();
                 byte[] buf = new byte[1024];
@@ -220,9 +241,12 @@ public class SnappyCombinedFuzzer {
                 while ((read = in.read(buf)) != -1) {
                     result.write(buf, 0, read);
                 }
+                if (!Arrays.equals(original, result.toByteArray())) {
+                    throw new IllegalStateException("Block stream roundtrip failed");
+                }
             }
         });
-        
+
         runFuzz(() -> {
             try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
                 while (in.read() != -1) {}
@@ -231,40 +255,45 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testUtil(FuzzedDataProvider data) {
-        byte[] input = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
-            String str = new String(input, java.nio.charset.StandardCharsets.UTF_8);
+            String str = data.consumeString(data.consumeInt(0, 4096));
             byte[] compressed = Snappy.compress(str);
             String uncompressed = Snappy.uncompressString(compressed);
-        });
-        
-        runFuzz(() -> {
-            int maxLen = Snappy.maxCompressedLength(input.length);
-        });
-        
-        runFuzz(() -> {
-            short[] shortInput = new short[Math.min(100, input.length / 2)];
-            for (int i = 0; i < shortInput.length; i++) {
-                shortInput[i] = (short) data.consumeInt();
+            if (!str.equals(uncompressed)) {
+                throw new IllegalStateException("String roundtrip failed");
             }
+        });
+
+        runFuzz(() -> {
+            int len = data.consumeInt(0, 4096);
+            int maxLen = Snappy.maxCompressedLength(len);
+            if (maxLen < len) {
+                throw new IllegalStateException("maxCompressedLength too small");
+            }
+        });
+
+        runFuzz(() -> {
+            short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
             byte[] compressedShorts = Snappy.compress(shortInput);
             short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
-        });
-        
-        runFuzz(() -> {
-            char[] charInput = new char[Math.min(100, input.length)];
-            for (int i = 0; i < charInput.length; i++) {
-                charInput[i] = (char) data.consumeInt();
+            if (!Arrays.equals(shortInput, uncompressedShorts)) {
+                throw new IllegalStateException("Short array roundtrip failed");
             }
+        });
+
+        runFuzz(() -> {
+            char[] charInput = data.consumeString(data.consumeInt(0, 100)).toCharArray();
             byte[] compressedChars = Snappy.compress(charInput);
             char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
+            if (!Arrays.equals(charInput, uncompressedChars)) {
+                throw new IllegalStateException("Char array roundtrip failed");
+            }
         });
     }
 
     private static void testBitShuffle(FuzzedDataProvider data) {
         runFuzz(() -> {
-            int[] intInput = data.consumeInts(100);
+            int[] intInput = data.consumeInts(data.consumeInt(0, 100));
             byte[] shuffled = BitShuffle.shuffle(intInput);
             int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
             if (!Arrays.equals(intInput, unshuffled)) {
@@ -273,7 +302,7 @@ public class SnappyCombinedFuzzer {
         });
         
         runFuzz(() -> {
-            long[] longInput = data.consumeLongs(50);
+            long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
             byte[] shuffled = BitShuffle.shuffle(longInput);
             long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
             if (!Arrays.equals(longInput, unshuffled)) {
@@ -282,7 +311,7 @@ public class SnappyCombinedFuzzer {
         });
         
         runFuzz(() -> {
-            short[] shortInput = data.consumeShorts(100);
+            short[] shortInput = data.consumeShorts(data.consumeInt(0, 100));
             byte[] shuffled = BitShuffle.shuffle(shortInput);
             short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
             if (!Arrays.equals(shortInput, unshuffled)) {
@@ -292,15 +321,14 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testHadoopStream(FuzzedDataProvider data) {
-        byte[] original = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
+            byte[] original = data.consumeBytes(data.consumeInt(0, 4096));
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyHadoopCompatibleOutputStream out = new SnappyHadoopCompatibleOutputStream(compressedBuf);
             out.write(original);
             out.close();
             byte[] compressed = compressedBuf.toByteArray();
-            
+
             try (SnappyInputStream in = new SnappyInputStream(
                 new ByteArrayInputStream(compressed))) {
                 ByteArrayOutputStream result = new ByteArrayOutputStream();
@@ -309,14 +337,16 @@ public class SnappyCombinedFuzzer {
                 while ((read = in.read(buf)) != -1) {
                     result.write(buf, 0, read);
                 }
+                if (!Arrays.equals(original, result.toByteArray())) {
+                    throw new IllegalStateException("Hadoop stream roundtrip failed");
+                }
             }
         });
     }
 
     private static void testByteBuffer(FuzzedDataProvider data) {
-        byte[] input = data.consumeRemainingAsBytes();
-        
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             ByteBuffer src = ByteBuffer.allocateDirect(input.length);
             src.put(input);
             src.flip();
@@ -339,6 +369,7 @@ public class SnappyCombinedFuzzer {
         });
         
         runFuzz(() -> {
+            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
             ByteBuffer directSrc = ByteBuffer.allocateDirect(input.length);
             directSrc.put(input);
             directSrc.flip();

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -149,7 +149,7 @@ public class SnappyCombinedFuzzer {
             new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (invalidIn.read() != -1) {}
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            // Expected, ignore.
         }
     }
 

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -130,25 +130,26 @@ public class SnappyCombinedFuzzer {
             byte[] compressed = compressedBuf.toByteArray();
             
             for (int bufferSize : new int[]{1, 64, 256, 1024, 4096}) {
-                SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
-                    new ByteArrayInputStream(compressed), true);
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                byte[] buf = new byte[bufferSize];
-                int readBytes;
-                while ((readBytes = framedIn.read(buf)) != -1) {
-                    out.write(buf, 0, readBytes);
+                try (SnappyFramedInputStream framedIn = new SnappyFramedInputStream(
+                    new ByteArrayInputStream(compressed), true)) {
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    byte[] buf = new byte[bufferSize];
+                    int readBytes;
+                    while ((readBytes = framedIn.read(buf)) != -1) {
+                        out.write(buf, 0, readBytes);
+                    }
+                    out.flush();
                 }
-                out.flush();
             }
         } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         
-        try {
-            byte[] invalidData = data.consumeBytes(100);
-            SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
-                new ByteArrayInputStream(invalidData));
+        try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
+            new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (invalidIn.read() != -1) {}
         } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -207,22 +208,22 @@ public class SnappyCombinedFuzzer {
             out.close();
             byte[] compressed = compressedBuf.toByteArray();
             
-            SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed));
-            ByteArrayOutputStream result = new ByteArrayOutputStream();
-            byte[] buf = new byte[1024];
-            int read;
-            while ((read = in.read(buf)) != -1) {
-                result.write(buf, 0, read);
+            try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+                ByteArrayOutputStream result = new ByteArrayOutputStream();
+                byte[] buf = new byte[1024];
+                int read;
+                while ((read = in.read(buf)) != -1) {
+                    result.write(buf, 0, read);
+                }
             }
-            in.close();
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         
-        try {
-            byte[] invalid = data.consumeBytes(100);
-            SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(invalid));
+        try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (in.read() != -1) {}
         } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -72,76 +72,86 @@ public class SnappyCombinedFuzzer {
     }
 
     private static void testRawApi(FuzzedDataProvider data) {
-        runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            byte[] compressed = Snappy.compress(input);
-            byte[] uncompressed = Snappy.uncompress(compressed);
-            if (!Arrays.equals(input, uncompressed)) {
-                throw new IllegalStateException("Raw compress/uncompress failed");
-            }
-        });
-
-        runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            byte[] rawCompressed = Snappy.rawCompress(input, input.length);
-            if (Snappy.isValidCompressedBuffer(rawCompressed)) {
-                int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
-                if (uncompressedLen == input.length) {
-                    byte[] rawUncompressed = new byte[uncompressedLen];
-                    Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
-                    if (!Arrays.equals(input, rawUncompressed)) {
-                        throw new IllegalStateException("Raw compress/uncompress with byte[] failed");
+        switch (data.consumeInt(0, 6)) {
+            case 0:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    byte[] compressed = Snappy.compress(input);
+                    byte[] uncompressed = Snappy.uncompress(compressed);
+                    if (!Arrays.equals(input, uncompressed)) {
+                        throw new IllegalStateException("Raw compress/uncompress failed");
                     }
-                }
-            }
-        });
-
-        runFuzz(() -> {
-            try {
-                byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-                Snappy.isValidCompressedBuffer(input);
-                Snappy.isValidCompressedBuffer(input, 0, input.length);
-            } catch (IOException e) {
-            }
-        });
-
-        runFuzz(() -> {
-            int inputLength = data.consumeInt(0, 4096);
-            int maxLen = Snappy.maxCompressedLength(inputLength);
-            if (maxLen < inputLength) {
-                throw new IllegalStateException("maxCompressedLength too small");
-            }
-        });
-
-        runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            byte[] compressed = Snappy.compress(input);
-            if (Snappy.isValidCompressedBuffer(compressed)) {
-                int len = Snappy.uncompressedLength(compressed);
-                int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
-                if (len != input.length || len2 != input.length) {
-                    throw new IllegalStateException("uncompressedLength did not match original length");
-                }
-            }
-        });
-
-        runFuzz(() -> {
-            int[] intInput = data.consumeInts(data.consumeInt(0, 100));
-            byte[] compressedInts = Snappy.compress(intInput);
-            int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
-            if (!Arrays.equals(intInput, uncompressedInts)) {
-                throw new IllegalStateException("Int array roundtrip failed");
-            }
-        });
-
-        runFuzz(() -> {
-            long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
-            byte[] compressedLongs = Snappy.compress(longInput);
-            long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
-            if (!Arrays.equals(longInput, uncompressedLongs)) {
-                throw new IllegalStateException("Long array roundtrip failed");
-            }
-        });
+                });
+                break;
+            case 1:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    byte[] rawCompressed = Snappy.rawCompress(input, input.length);
+                    if (Snappy.isValidCompressedBuffer(rawCompressed)) {
+                        int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
+                        if (uncompressedLen == input.length) {
+                            byte[] rawUncompressed = new byte[uncompressedLen];
+                            Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
+                            if (!Arrays.equals(input, rawUncompressed)) {
+                                throw new IllegalStateException("Raw compress/uncompress with byte[] failed");
+                            }
+                        }
+                    }
+                });
+                break;
+            case 2:
+                runFuzz(() -> {
+                    try {
+                        byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                        Snappy.isValidCompressedBuffer(input);
+                        Snappy.isValidCompressedBuffer(input, 0, input.length);
+                    } catch (IOException e) {
+                    }
+                });
+                break;
+            case 3:
+                runFuzz(() -> {
+                    int inputLength = data.consumeInt(0, 4096);
+                    int maxLen = Snappy.maxCompressedLength(inputLength);
+                    if (maxLen < inputLength) {
+                        throw new IllegalStateException("maxCompressedLength too small");
+                    }
+                });
+                break;
+            case 4:
+                runFuzz(() -> {
+                    byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
+                    byte[] compressed = Snappy.compress(input);
+                    if (Snappy.isValidCompressedBuffer(compressed)) {
+                        int len = Snappy.uncompressedLength(compressed);
+                        int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
+                        if (len != input.length || len2 != input.length) {
+                            throw new IllegalStateException("uncompressedLength did not match original length");
+                        }
+                    }
+                });
+                break;
+            case 5:
+                runFuzz(() -> {
+                    int[] intInput = data.consumeInts(data.consumeInt(0, 100));
+                    byte[] compressedInts = Snappy.compress(intInput);
+                    int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
+                    if (!Arrays.equals(intInput, uncompressedInts)) {
+                        throw new IllegalStateException("Int array roundtrip failed");
+                    }
+                });
+                break;
+            case 6:
+                runFuzz(() -> {
+                    long[] longInput = data.consumeLongs(data.consumeInt(0, 50));
+                    byte[] compressedLongs = Snappy.compress(longInput);
+                    long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
+                    if (!Arrays.equals(longInput, uncompressedLongs)) {
+                        throw new IllegalStateException("Long array roundtrip failed");
+                    }
+                });
+                break;
+        }
     }
 
     private static void testFramed(FuzzedDataProvider data) {

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 
 public class SnappyCombinedFuzzer {
     
+    @FunctionalInterface
     private interface FuzzBlock {
         void run() throws Exception;
     }
@@ -180,14 +181,15 @@ public class SnappyCombinedFuzzer {
 
     private static void testCrc32C(FuzzedDataProvider data) {
         byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-        byte[] chunk1 = data.consumeBytes(50);
-        byte[] chunk2 = data.consumeBytes(50);
         
         PureJavaCrc32C crc = new PureJavaCrc32C();
         crc.update(input, 0, input.length);
         long value = crc.getValue();
         
         int intValue = crc.getIntegerValue();
+        if ((int) value != intValue) {
+            throw new IllegalStateException("CRC32C int value mismatch");
+        }
         
         crc.reset();
         crc.update(input, 0, input.length);
@@ -200,41 +202,13 @@ public class SnappyCombinedFuzzer {
         for (int i = 0; i < Math.min(input.length, 1000); i++) {
             crcChunked.update(input[i] & 0xFF);
         }
-        long chunkedValue = crcChunked.getValue();
         
         PureJavaCrc32C crcWhole = new PureJavaCrc32C();
         crcWhole.update(input, 0, input.length);
         long wholeValue = crcWhole.getValue();
         
-        if (input.length <= 1000 && chunkedValue != wholeValue) {
+        if (input.length <= 1000 && crcChunked.getValue() != wholeValue) {
             throw new IllegalStateException("CRC32C chunked vs whole mismatch");
-        }
-        
-        if (chunk1.length > 0 && chunk2.length > 0) {
-            PureJavaCrc32C crc1 = new PureJavaCrc32C();
-            crc1.update(input, 0, input.length);
-            long crc1Value = crc1.getValue();
-            
-            PureJavaCrc32C crc2 = new PureJavaCrc32C();
-            crc2.update(chunk1, 0, chunk1.length);
-            crc2.update(chunk2, 0, chunk2.length);
-            long crc2Value = crc2.getValue();
-        }
-        
-        PureJavaCrc32C crcEmpty = new PureJavaCrc32C();
-        crcEmpty.update(new byte[0], 0, 0);
-        long emptyValue = crcEmpty.getValue();
-        
-        if (input.length > 0) {
-            PureJavaCrc32C crcSingle = new PureJavaCrc32C();
-            crcSingle.update(input[0] & 0xFF);
-            long singleValue = crcSingle.getValue();
-        }
-        
-        if (input.length > 4) {
-            PureJavaCrc32C crcOffset = new PureJavaCrc32C();
-            crcOffset.update(input, 1, input.length - 1);
-            long offsetValue = crcOffset.getValue();
         }
     }
 

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -33,11 +33,6 @@ import java.util.Arrays;
 
 public class SnappyCombinedFuzzer {
     
-    @FunctionalInterface
-    private interface FuzzBlock {
-        void run() throws Exception;
-    }
-    
     private static void runFuzz(FuzzBlock block) {
         try {
             block.run();
@@ -199,15 +194,14 @@ public class SnappyCombinedFuzzer {
         }
         
         PureJavaCrc32C crcChunked = new PureJavaCrc32C();
-        for (int i = 0; i < Math.min(input.length, 1000); i++) {
+        for (int i = 0; i < input.length; i++) {
             crcChunked.update(input[i] & 0xFF);
         }
         
         PureJavaCrc32C crcWhole = new PureJavaCrc32C();
         crcWhole.update(input, 0, input.length);
-        long wholeValue = crcWhole.getValue();
         
-        if (input.length <= 1000 && crcChunked.getValue() != wholeValue) {
+        if (crcChunked.getValue() != crcWhole.getValue()) {
             throw new IllegalStateException("CRC32C chunked vs whole mismatch");
         }
     }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -32,6 +32,19 @@ import java.io.IOException;
 import java.util.Arrays;
 
 public class SnappyCombinedFuzzer {
+    
+    private interface FuzzBlock {
+        void run() throws Exception;
+    }
+    
+    private static void runFuzz(FuzzBlock block) {
+        try {
+            block.run();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int selector = data.consumeInt(0, 7);
         switch (selector) {
@@ -65,70 +78,56 @@ public class SnappyCombinedFuzzer {
     private static void testRawApi(FuzzedDataProvider data) {
         byte[] input = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             byte[] compressed = Snappy.compress(input);
             byte[] uncompressed = Snappy.uncompress(compressed);
             if (!Arrays.equals(input, uncompressed)) {
                 throw new IllegalStateException("Raw compress/uncompress failed");
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             byte[] rawCompressed = Snappy.rawCompress(input, input.length);
             int uncompressedLen = Snappy.uncompressedLength(rawCompressed);
             byte[] rawUncompressed = new byte[uncompressedLen];
             Snappy.rawUncompress(rawCompressed, 0, rawCompressed.length, rawUncompressed, 0);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             Snappy.isValidCompressedBuffer(input);
             Snappy.isValidCompressedBuffer(input, 0, input.length);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             int maxLen = Snappy.maxCompressedLength(input.length);
             if (maxLen < input.length) {
                 throw new IllegalStateException("maxCompressedLength too small");
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             byte[] compressed = Snappy.compress(input);
             int len = Snappy.uncompressedLength(compressed);
             int len2 = Snappy.uncompressedLength(compressed, 0, compressed.length);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             int[] intInput = data.consumeInts(100);
             byte[] compressedInts = Snappy.compress(intInput);
             int[] uncompressedInts = Snappy.uncompressIntArray(compressedInts);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             long[] longInput = data.consumeLongs(50);
             byte[] compressedLongs = Snappy.compress(longInput);
             long[] uncompressedLongs = Snappy.uncompressLongArray(compressedLongs);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
     }
 
     private static void testFramed(FuzzedDataProvider data) {
         byte[] original = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyFramedOutputStream framedOut = new SnappyFramedOutputStream(compressedBuf);
             framedOut.write(original);
@@ -147,22 +146,22 @@ public class SnappyCombinedFuzzer {
                     out.flush();
                 }
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
-            new ByteArrayInputStream(data.consumeBytes(100)))) {
-            while (invalidIn.read() != -1) {}
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        runFuzz(() -> {
+            try (SnappyFramedInputStream invalidIn = new SnappyFramedInputStream(
+                new ByteArrayInputStream(data.consumeBytes(100)))) {
+                while (invalidIn.read() != -1) {}
+            }
+        });
     }
 
     private static void testCrc32C(FuzzedDataProvider data) {
         byte[] input = data.consumeRemainingAsBytes();
-        PureJavaCrc32C crc = new PureJavaCrc32C();
+        byte[] chunk1 = data.consumeBytes(50);
+        byte[] chunk2 = data.consumeBytes(50);
         
+        PureJavaCrc32C crc = new PureJavaCrc32C();
         crc.update(input, 0, input.length);
         long value = crc.getValue();
         
@@ -171,22 +170,22 @@ public class SnappyCombinedFuzzer {
         crc.reset();
         crc.update(input, 0, input.length);
         long value2 = crc.getValue();
+        if (value != value2) {
+            throw new IllegalStateException("CRC32C reset produced different value");
+        }
         
         PureJavaCrc32C crcChunked = new PureJavaCrc32C();
         for (int i = 0; i < Math.min(input.length, 1000); i++) {
             crcChunked.update(input[i] & 0xFF);
         }
         
-        if (input.length > 2) {
-            byte[] partial1 = data.consumeBytes(Math.min(10, input.length));
-            byte[] partial2 = data.consumeBytes(Math.min(10, input.length));
-            
+        if (chunk1.length > 0 && chunk2.length > 0) {
             PureJavaCrc32C crc1 = new PureJavaCrc32C();
             crc1.update(input, 0, input.length);
             
             PureJavaCrc32C crc2 = new PureJavaCrc32C();
-            crc2.update(partial1, 0, partial1.length);
-            crc2.update(partial2, 0, partial2.length);
+            crc2.update(chunk1, 0, chunk1.length);
+            crc2.update(chunk2, 0, chunk2.length);
         }
         
         PureJavaCrc32C crcEmpty = new PureJavaCrc32C();
@@ -207,7 +206,7 @@ public class SnappyCombinedFuzzer {
     private static void testBlockStream(FuzzedDataProvider data) {
         byte[] original = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyOutputStream out = new SnappyOutputStream(compressedBuf, -1);
             out.write(original);
@@ -222,87 +221,80 @@ public class SnappyCombinedFuzzer {
                     result.write(buf, 0, read);
                 }
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
-            while (in.read() != -1) {}
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        runFuzz(() -> {
+            try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
+                while (in.read() != -1) {}
+            }
+        });
     }
 
     private static void testUtil(FuzzedDataProvider data) {
         byte[] input = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             String str = new String(input, java.nio.charset.StandardCharsets.UTF_8);
             byte[] compressed = Snappy.compress(str);
             String uncompressed = Snappy.uncompressString(compressed);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             int maxLen = Snappy.maxCompressedLength(input.length);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             short[] shortInput = new short[Math.min(100, input.length / 2)];
             for (int i = 0; i < shortInput.length; i++) {
                 shortInput[i] = (short) data.consumeInt();
             }
             byte[] compressedShorts = Snappy.compress(shortInput);
             short[] uncompressedShorts = Snappy.uncompressShortArray(compressedShorts);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             char[] charInput = new char[Math.min(100, input.length)];
             for (int i = 0; i < charInput.length; i++) {
                 charInput[i] = (char) data.consumeInt();
             }
             byte[] compressedChars = Snappy.compress(charInput);
             char[] uncompressedChars = Snappy.uncompressCharArray(compressedChars);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
     }
 
     private static void testBitShuffle(FuzzedDataProvider data) {
-        try {
+        runFuzz(() -> {
             int[] intInput = data.consumeInts(100);
             byte[] shuffled = BitShuffle.shuffle(intInput);
             int[] unshuffled = BitShuffle.unshuffleIntArray(shuffled);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+            if (!Arrays.equals(intInput, unshuffled)) {
+                throw new IllegalStateException("BitShuffle int failed");
+            }
+        });
         
-        try {
+        runFuzz(() -> {
             long[] longInput = data.consumeLongs(50);
             byte[] shuffled = BitShuffle.shuffle(longInput);
             long[] unshuffled = BitShuffle.unshuffleLongArray(shuffled);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+            if (!Arrays.equals(longInput, unshuffled)) {
+                throw new IllegalStateException("BitShuffle long failed");
+            }
+        });
         
-        try {
+        runFuzz(() -> {
             short[] shortInput = data.consumeShorts(100);
             byte[] shuffled = BitShuffle.shuffle(shortInput);
             short[] unshuffled = BitShuffle.unshuffleShortArray(shuffled);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+            if (!Arrays.equals(shortInput, unshuffled)) {
+                throw new IllegalStateException("BitShuffle short failed");
+            }
+        });
     }
 
     private static void testHadoopStream(FuzzedDataProvider data) {
         byte[] original = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
             SnappyHadoopCompatibleOutputStream out = new SnappyHadoopCompatibleOutputStream(compressedBuf);
             out.write(original);
@@ -318,15 +310,13 @@ public class SnappyCombinedFuzzer {
                     result.write(buf, 0, read);
                 }
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
     }
 
     private static void testByteBuffer(FuzzedDataProvider data) {
         byte[] input = data.consumeRemainingAsBytes();
         
-        try {
+        runFuzz(() -> {
             ByteBuffer src = ByteBuffer.allocateDirect(input.length);
             src.put(input);
             src.flip();
@@ -346,19 +336,15 @@ public class SnappyCombinedFuzzer {
             if (!Arrays.equals(input, result)) {
                 throw new IllegalStateException("ByteBuffer compress failed");
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
         
-        try {
+        runFuzz(() -> {
             ByteBuffer directSrc = ByteBuffer.allocateDirect(input.length);
             directSrc.put(input);
             directSrc.flip();
             
             ByteBuffer directDst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
             Snappy.compress(directSrc, directDst);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        });
     }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -223,7 +223,7 @@ public class SnappyCombinedFuzzer {
         try (SnappyInputStream in = new SnappyInputStream(new ByteArrayInputStream(data.consumeBytes(100)))) {
             while (in.read() != -1) {}
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            // Expected, ignore.
         }
     }
 

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -200,14 +200,25 @@ public class SnappyCombinedFuzzer {
         for (int i = 0; i < Math.min(input.length, 1000); i++) {
             crcChunked.update(input[i] & 0xFF);
         }
+        long chunkedValue = crcChunked.getValue();
+        
+        PureJavaCrc32C crcWhole = new PureJavaCrc32C();
+        crcWhole.update(input, 0, input.length);
+        long wholeValue = crcWhole.getValue();
+        
+        if (input.length <= 1000 && chunkedValue != wholeValue) {
+            throw new IllegalStateException("CRC32C chunked vs whole mismatch");
+        }
         
         if (chunk1.length > 0 && chunk2.length > 0) {
             PureJavaCrc32C crc1 = new PureJavaCrc32C();
             crc1.update(input, 0, input.length);
+            long crc1Value = crc1.getValue();
             
             PureJavaCrc32C crc2 = new PureJavaCrc32C();
             crc2.update(chunk1, 0, chunk1.length);
             crc2.update(chunk2, 0, chunk2.length);
+            long crc2Value = crc2.getValue();
         }
         
         PureJavaCrc32C crcEmpty = new PureJavaCrc32C();
@@ -217,11 +228,13 @@ public class SnappyCombinedFuzzer {
         if (input.length > 0) {
             PureJavaCrc32C crcSingle = new PureJavaCrc32C();
             crcSingle.update(input[0] & 0xFF);
+            long singleValue = crcSingle.getValue();
         }
         
         if (input.length > 4) {
             PureJavaCrc32C crcOffset = new PureJavaCrc32C();
             crcOffset.update(input, 1, input.length - 1);
+            long offsetValue = crcOffset.getValue();
         }
     }
 
@@ -366,16 +379,6 @@ public class SnappyCombinedFuzzer {
             if (!Arrays.equals(input, result)) {
                 throw new IllegalStateException("ByteBuffer compress failed");
             }
-        });
-        
-        runFuzz(() -> {
-            byte[] input = data.consumeBytes(data.consumeInt(0, 4096));
-            ByteBuffer directSrc = ByteBuffer.allocateDirect(input.length);
-            directSrc.put(input);
-            directSrc.flip();
-            
-            ByteBuffer directDst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
-            Snappy.compress(directSrc, directDst);
         });
     }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
@@ -311,16 +311,19 @@ public class SnappyCombinedFuzzer {
         byte[] input = data.consumeRemainingAsBytes();
         
         try {
-            ByteBuffer src = ByteBuffer.wrap(input);
-            ByteBuffer dst = ByteBuffer.allocate(Snappy.maxCompressedLength(input.length));
+            ByteBuffer src = ByteBuffer.allocateDirect(input.length);
+            src.put(input);
+            src.flip();
+            ByteBuffer dst = ByteBuffer.allocateDirect(Snappy.maxCompressedLength(input.length));
             int compressed = Snappy.compress(src, dst);
             
             dst.limit(compressed);
             dst.position(0);
-            ByteBuffer uncompressedBuf = ByteBuffer.allocate(input.length);
+            ByteBuffer uncompressedBuf = ByteBuffer.allocateDirect(input.length);
             int uncompressed = Snappy.uncompress(dst, uncompressedBuf);
             
             uncompressedBuf.limit(uncompressed);
+            uncompressedBuf.position(0);
             byte[] result = new byte[uncompressed];
             uncompressedBuf.get(result);
             

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -17,10 +17,12 @@
 package org.xerial.snappy.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
 import org.xerial.snappy.SnappyInputStream;
 import org.xerial.snappy.SnappyOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 
 /**
@@ -38,8 +40,20 @@ public class SnappyStreamFuzzer {
         }
     }
     
+    @FuzzTest
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        int selector = data.consumeInt(0, 1);
+        
+        if (selector == 0) {
+            testRoundtrip(data);
+        } else {
+            testMalformedInput(data);
+        }
+    }
+    
+    private static void testRoundtrip(FuzzedDataProvider data) {
         byte[] original = data.consumeRemainingAsBytes();
+        int bufferSize = data.consumeInt(1, 8192);
         
         runFuzz(() -> {
             ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
@@ -51,7 +65,7 @@ public class SnappyStreamFuzzer {
             byte[] uncompressed;
             try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
-                byte[] buf = new byte[4096];
+                byte[] buf = new byte[bufferSize];
                 int readBytes;
                 while ((readBytes = snappyIn.read(buf)) != -1) {
                     out.write(buf, 0, readBytes);
@@ -61,6 +75,17 @@ public class SnappyStreamFuzzer {
 
             if (!Arrays.equals(original, uncompressed)) {
                 throw new IllegalStateException("Original and uncompressed data are different");
+            }
+        });
+    }
+    
+    private static void testMalformedInput(FuzzedDataProvider data) {
+        runFuzz(() -> {
+            try (SnappyInputStream in = new SnappyInputStream(
+                new ByteArrayInputStream(data.consumeBytes(100)))) {
+                while (in.read() != -1) {}
+            } catch (IOException e) {
+                // Expected for malformed input during fuzzing
             }
         });
     }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -32,7 +32,7 @@ public class SnappyStreamFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {    
 
     byte[] original = data.consumeRemainingAsBytes();
-    byte[] uncompressed;
+    byte[] uncompressed = null;
     
     try {
       ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -31,11 +31,6 @@ import java.util.Arrays;
  */
 public class SnappyStreamFuzzer {
     
-    @FunctionalInterface
-    private interface FuzzBlock {
-        void run() throws Exception;
-    }
-    
     private static void runFuzz(FuzzBlock block) {
         try {
             block.run();

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -24,35 +24,50 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
+/**
+ * Fuzzer for Snappy's block-based stream format, as implemented by
+ * {@link SnappyOutputStream} and {@link SnappyInputStream}.
+ * This is different from the "x-snappy-framed" format.
+ */
 public class SnappyStreamFuzzer {
-  public static void fuzzerTestOneInput(FuzzedDataProvider data) {    
-
-    byte[] original = data.consumeRemainingAsBytes();
     
-    try {
-      ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
-      SnappyOutputStream snappyOut = new SnappyOutputStream(compressedBuf);
-      snappyOut.write(original);
-      snappyOut.close();
-      byte[] compressed = compressedBuf.toByteArray();
-      
-      byte[] uncompressed;
-      try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        byte[] buf = new byte[4096];
-        int readBytes;
-        while ((readBytes = snappyIn.read(buf)) != -1) {
-            out.write(buf, 0, readBytes);
+    @FunctionalInterface
+    private interface FuzzBlock {
+        void run() throws Exception;
+    }
+    
+    private static void runFuzz(FuzzBlock block) {
+        try {
+            block.run();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-        out.flush();
-        uncompressed = out.toByteArray();
-      }
+    }
+    
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        byte[] original = data.consumeRemainingAsBytes();
+        
+        runFuzz(() -> {
+            ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+            try (SnappyOutputStream snappyOut = new SnappyOutputStream(compressedBuf)) {
+                snappyOut.write(original);
+            }
+            byte[] compressed = compressedBuf.toByteArray();
 
-      if (!Arrays.equals(original, uncompressed)) {
-        throw new IllegalStateException("Original and uncompressed data are different");
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }    
-  }
+            byte[] uncompressed;
+            try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buf = new byte[4096];
+                int readBytes;
+                while ((readBytes = snappyIn.read(buf)) != -1) {
+                    out.write(buf, 0, readBytes);
+                }
+                uncompressed = out.toByteArray();
+            }
+
+            if (!Arrays.equals(original, uncompressed)) {
+                throw new IllegalStateException("Original and uncompressed data are different");
+            }
+        });
+    }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -1,0 +1,62 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package org.xerial.snappy.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.xerial.snappy.Snappy;
+import org.xerial.snappy.SnappyInputStream;
+import org.xerial.snappy.SnappyOutputStream;
+import org.xerial.snappy.SnappyCodec;
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.BufferedInputStream;
+import java.util.Arrays;
+
+public class SnappyStreamFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {    
+
+    byte[] original = data.consumeRemainingAsBytes();
+    byte[] uncompressed;
+    
+    try {
+      ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
+      SnappyOutputStream snappyOut = new SnappyOutputStream(compressedBuf);
+      snappyOut.write(original);
+      snappyOut.close();
+      byte[] compressed = compressedBuf.toByteArray();
+      SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed));
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      byte[] buf = new byte[4096];
+      for (int readBytes = 0; (readBytes = snappyIn.read(buf)) != -1; ) {
+          out.write(buf, 0, readBytes);
+      }
+      out.flush();
+      uncompressed = out.toByteArray();
+    }
+    catch (IOException e)
+    {
+      return;
+    }
+    
+    if(Arrays.equals(original,uncompressed) == false)
+    {
+      throw new IllegalStateException("Original and uncompressed data are different");
+    }    
+  }
+}

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -44,7 +44,8 @@ public class SnappyStreamFuzzer {
       try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] buf = new byte[4096];
-        for (int readBytes = 0; (readBytes = snappyIn.read(buf)) != -1; ) {
+        int readBytes;
+        while ((readBytes = snappyIn.read(buf)) != -1) {
             out.write(buf, 0, readBytes);
         }
         out.flush();

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -28,7 +28,6 @@ public class SnappyStreamFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {    
 
     byte[] original = data.consumeRemainingAsBytes();
-    byte[] uncompressed = null;
     
     try {
       ByteArrayOutputStream compressedBuf = new ByteArrayOutputStream();
@@ -37,6 +36,7 @@ public class SnappyStreamFuzzer {
       snappyOut.close();
       byte[] compressed = compressedBuf.toByteArray();
       
+      byte[] uncompressed;
       try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] buf = new byte[4096];
@@ -47,12 +47,12 @@ public class SnappyStreamFuzzer {
         out.flush();
         uncompressed = out.toByteArray();
       }
+
+      if (!Arrays.equals(original, uncompressed)) {
+        throw new IllegalStateException("Original and uncompressed data are different");
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
-    }
-    
-    if (!Arrays.equals(original, uncompressed)) {
-      throw new IllegalStateException("Original and uncompressed data are different");
     }    
   }
 }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -19,7 +19,6 @@ package org.xerial.snappy.fuzz;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.xerial.snappy.SnappyInputStream;
 import org.xerial.snappy.SnappyOutputStream;
-import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -17,15 +17,11 @@
 package org.xerial.snappy.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-
-import org.xerial.snappy.Snappy;
 import org.xerial.snappy.SnappyInputStream;
 import org.xerial.snappy.SnappyOutputStream;
-import org.xerial.snappy.SnappyCodec;
 import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.BufferedInputStream;
 import java.util.Arrays;
 
 public class SnappyStreamFuzzer {
@@ -51,14 +47,11 @@ public class SnappyStreamFuzzer {
         out.flush();
         uncompressed = out.toByteArray();
       }
-    }
-    catch (IOException e)
-    {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
     
-    if(Arrays.equals(original,uncompressed) == false)
-    {
+    if (!Arrays.equals(original, uncompressed)) {
       throw new IllegalStateException("Original and uncompressed data are different");
     }    
   }

--- a/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
+++ b/src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
@@ -40,18 +40,20 @@ public class SnappyStreamFuzzer {
       snappyOut.write(original);
       snappyOut.close();
       byte[] compressed = compressedBuf.toByteArray();
-      SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed));
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      byte[] buf = new byte[4096];
-      for (int readBytes = 0; (readBytes = snappyIn.read(buf)) != -1; ) {
-          out.write(buf, 0, readBytes);
+      
+      try (SnappyInputStream snappyIn = new SnappyInputStream(new ByteArrayInputStream(compressed))) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[4096];
+        for (int readBytes = 0; (readBytes = snappyIn.read(buf)) != -1; ) {
+            out.write(buf, 0, readBytes);
+        }
+        out.flush();
+        uncompressed = out.toByteArray();
       }
-      out.flush();
-      uncompressed = out.toByteArray();
     }
     catch (IOException e)
     {
-      return;
+      throw new RuntimeException(e);
     }
     
     if(Arrays.equals(original,uncompressed) == false)


### PR DESCRIPTION
With this PR we will be fuzzing targets to enable continuous security testing via **CIFuzz** and **OSS-Fuzz**.

### Summary

- SnappyCombinedFuzzer covers the Raw API, Framed streams, CRC32C, Block streams, Util methods, Hadoop streams, and ByteBuffer APIs.
- BitShuffleFuzzer covers the BitShuffle algorithm.
- SnappyStreamFuzzer covers Snappy framed streams.

### Files Added

.github/workflows/cifuzz.yml
src/test/java/org/xerial/snappy/fuzz/SnappyCombinedFuzzer.java
src/test/java/org/xerial/snappy/fuzz/BitShuffleFuzzer.java
src/test/java/org/xerial/snappy/fuzz/SnappyStreamFuzzer.java
### Key Points


**Minimal footprint**: Only 3 fuzzers added to keep the codebase lean.
**No build changes**: Works seamlessly with the existing sbt build system.
**CIFuzz ready**: Includes a dedicated GitHub Actions workflow for automated testing.
**Broad coverage**: The combined fuzzer alone covers 8 different APIs.

All fuzzers currently compile successfully and are ready for integration.
